### PR TITLE
feat(send): add --diff-since-jip to diff against jip's last send

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -35,6 +35,7 @@ func init() {
 	sendCmd.Flags().BoolP("existing", "x", false, "Only update PRs that already exist (skip new ones)")
 	sendCmd.Flags().Bool("no-stack", false, "Send only the tip of each stack as a single PR")
 	sendCmd.Flags().Bool("rebase", false, "Rebase the stack onto the base branch before sending")
+	sendCmd.Flags().Bool("diff-since-jip", false, "Diff against jip's own last send (recorded in the PR) instead of the current remote head, so direct pushes by others don't distort the \"changes since\" comment")
 
 	_ = sendCmd.RegisterFlagCompletionFunc("base", completeJJBookmarks)
 }
@@ -51,6 +52,7 @@ type sendOpts struct {
 	existing       bool
 	noStack        bool
 	rebase         bool
+	diffSinceJip   bool
 	reviewers      []string
 	revsets        []string
 }
@@ -95,6 +97,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 	existing, _ := cmd.Flags().GetBool("existing")
 	noStack, _ := cmd.Flags().GetBool("no-stack")
 	rebase, _ := cmd.Flags().GetBool("rebase")
+	diffSinceJip, _ := cmd.Flags().GetBool("diff-since-jip")
 	w := cmd.OutOrStdout()
 
 	revsets := args
@@ -172,6 +175,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		existing:       existing,
 		noStack:        noStack,
 		rebase:         rebase,
+		diffSinceJip:   diffSinceJip,
 		reviewers:      reviewers,
 		revsets:        revsets,
 	}, w)
@@ -527,19 +531,15 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 					s.changed = true
 				}
 
-				// Post interdiff comment: compare the old remote commit to the new local commit.
+				// Post "changes since" comment. By default the base is the old
+				// remote commit; with --diff-since-jip it is jip's own previous
+				// push (recorded in the PR body), so direct pushes by others
+				// don't distort the diff.
 				bi := bookmarkByName[s.bookmark.Bookmark]
 				if bi != nil {
-					if rs, ok := bi.Remotes[opts.remote]; ok && rs.Target != "" && rs.Target != s.change.CommitID {
-						diff, err := runner.Interdiff(rs.Target, s.change.CommitID)
-						if err != nil {
-							_, _ = fmt.Fprintf(w, "  warning: interdiff failed for #%d: %v\n", s.pr.Number, err)
-						} else {
-							comment := gh.BuildDiffComment(diff, repoFullName, baseBranch, rs.Target, s.change.CommitID)
-							if err := client.CommentOnPR(s.pr.Number, comment); err != nil {
-								return fmt.Errorf("commenting on PR #%d: %w", s.pr.Number, err)
-							}
-							s.changed = true
+					if rs, ok := bi.Remotes[opts.remote]; ok {
+						if err := postChangesComment(runner, client, s, rs.Target, repoFullName, baseBranch, opts.diffSinceJip, w); err != nil {
+							return err
 						}
 					}
 				}
@@ -568,26 +568,33 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 			}
 		}
 
-		// 9. Update all PR bodies with stack navigation (skip when --no-stack).
+		// 9. Update all PR bodies with stack navigation (skip nav when
+		// --no-stack) plus the invisible pushed-commit marker that records this
+		// push for a later --diff-since-jip.
+		//
+		// Each PR's stack only includes its ancestors and descendants (its
+		// dependency chain), not unrelated branches in the same DAG.
+		var perChangeStack [][]int
 		if !opts.noStack {
-			// Each PR's stack only includes its ancestors and descendants (its
-			// dependency chain), not unrelated branches in the same DAG.
-			perChangeStack := computeStackPRs(activeStates)
-
-			for i, s := range activeStates {
-				body := gh.BuildStackedPRBody(
+			perChangeStack = computeStackPRs(activeStates)
+		}
+		for i, s := range activeStates {
+			body := s.change.Body()
+			if !opts.noStack {
+				body = gh.BuildStackedPRBody(
 					s.change.CommitID,
 					repoFullName,
 					s.pr.Number,
 					perChangeStack[i],
 					s.change.Body(),
 				)
-				if body != s.pr.Body {
-					if err := client.UpdatePR(s.pr.Number, gh.UpdatePROpts{Body: &body}); err != nil {
-						return fmt.Errorf("updating PR #%d body: %w", s.pr.Number, err)
-					}
-					activeStates[i].changed = true
+			}
+			body = gh.WithPushedCommitMarker(body, s.change.CommitID)
+			if body != s.pr.Body {
+				if err := client.UpdatePR(s.pr.Number, gh.UpdatePROpts{Body: &body}); err != nil {
+					return fmt.Errorf("updating PR #%d body: %w", s.pr.Number, err)
 				}
+				activeStates[i].changed = true
 			}
 		}
 
@@ -610,6 +617,64 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 		printAllSkipped(w, skippedStates, skippedIDs, preSkippedChanges)
 		return fmt.Errorf("%d change(s) skipped", totalSkipped)
 	}
+	return nil
+}
+
+// postChangesComment posts the "changes since" comment for an updated PR.
+//
+// The interdiff base is, in order of preference:
+//   - with --diff-since-jip: the commit jip recorded in the PR body (the
+//     pushed-commit marker, or the legacy "Only review commit" link), falling
+//     back to the remote head when the PR carries no jip record yet;
+//   - otherwise: the current remote head.
+//
+// When --diff-since-jip resolves the base from a jip record but that commit is
+// not available locally (e.g. another machine pushed it and we didn't fetch),
+// it documents that the diff could not be generated instead of computing one.
+func postChangesComment(runner jj.Runner, client gh.Service, s *changeState, remoteTarget, repoFullName, baseBranch string, sinceJip bool, w io.Writer) error {
+	newCommit := s.change.CommitID
+
+	base := remoteTarget
+	fromRecord := false
+	if sinceJip {
+		if rec := gh.ParsePushedCommit(s.pr.Body); rec != "" {
+			base, fromRecord = rec, true
+		} else if rec := gh.ParseReviewCommit(s.pr.Body); rec != "" {
+			base, fromRecord = rec, true
+		}
+	}
+
+	// Nothing to compare against, or nothing changed since the base.
+	if base == "" || base == newCommit {
+		return nil
+	}
+
+	// A base recovered from a jip record may not be present locally.
+	if fromRecord {
+		exists, err := runner.CommitExists(base)
+		if err != nil {
+			return fmt.Errorf("checking commit %s for #%d: %w", base, s.pr.Number, err)
+		}
+		if !exists {
+			comment := gh.BuildUnavailableDiffComment(repoFullName, baseBranch, base, newCommit)
+			if err := client.CommentOnPR(s.pr.Number, comment); err != nil {
+				return fmt.Errorf("commenting on PR #%d: %w", s.pr.Number, err)
+			}
+			s.changed = true
+			return nil
+		}
+	}
+
+	diff, err := runner.Interdiff(base, newCommit)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  warning: interdiff failed for #%d: %v\n", s.pr.Number, err)
+		return nil
+	}
+	comment := gh.BuildDiffComment(diff, repoFullName, baseBranch, base, newCommit, sinceJip && fromRecord)
+	if err := client.CommentOnPR(s.pr.Number, comment); err != nil {
+		return fmt.Errorf("commenting on PR #%d: %w", s.pr.Number, err)
+	}
+	s.changed = true
 	return nil
 }
 

--- a/cmd/send_integration_test.go
+++ b/cmd/send_integration_test.go
@@ -571,6 +571,162 @@ func TestIntegration_SendPostsInterdiffComment(t *testing.T) {
 	}
 }
 
+// After any send, the PR body should carry the invisible pushed-commit marker
+// recording the commit that was pushed, so a later --diff-since-jip can use it.
+func TestIntegration_SendEmbedsPushedCommitMarker(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "f.go", "package x\n\nconst V = 1\n", "feat: add f")
+	changeID := getChangeID(t, repoDir, "@-")
+
+	var buf bytes.Buffer
+	if err := executeSend(runner, mock, sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}}, &buf); err != nil {
+		t.Fatalf("send failed: %v\n%s", err, buf.String())
+	}
+
+	commit := getCommitID(t, repoDir, changeID)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	var pr *gh.PRInfo
+	for _, p := range mock.prs {
+		pr = p
+	}
+	if pr == nil {
+		t.Fatal("expected a PR")
+	}
+	if got := gh.ParsePushedCommit(pr.Body); got != commit {
+		t.Errorf("body marker = %q, want pushed commit %q\nbody:\n%s", got, commit, pr.Body)
+	}
+}
+
+// With --diff-since-jip, the interdiff base is the commit recorded in the PR
+// body, not the current remote head. This simulates the remote head having
+// advanced past jip's recorded push (e.g. a direct push by someone else).
+func TestIntegration_SendDiffSinceJipUsesRecordedBase(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "f.go", "package x\n\nconst V = 1\n", "feat: add f")
+	changeID := getChangeID(t, repoDir, "@-")
+
+	// Send 1: creates the PR. Record commit1.
+	var buf bytes.Buffer
+	if err := executeSend(runner, mock, sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}}, &buf); err != nil {
+		t.Fatalf("send 1 failed: %v\n%s", err, buf.String())
+	}
+	commit1 := getCommitID(t, repoDir, changeID)
+
+	var prNumber int
+	mock.mu.Lock()
+	for n := range mock.prs {
+		prNumber = n
+	}
+	mock.mu.Unlock()
+
+	// Edit to v2 and send again (default), moving the remote head to commit2.
+	editFile(t, repoDir, changeID, "f.go", "package x\n\nconst V = 2\n")
+	buf.Reset()
+	if err := executeSend(runner, mock, sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}}, &buf); err != nil {
+		t.Fatalf("send 2 failed: %v\n%s", err, buf.String())
+	}
+	commit2 := getCommitID(t, repoDir, changeID)
+
+	// Simulate desync: the PR's recorded jip push is still commit1 even though
+	// the remote head is now commit2.
+	mock.mu.Lock()
+	mock.prs[prNumber].Body = gh.WithPushedCommitMarker("feat: add f", commit1)
+	mock.comments[prNumber] = nil
+	mock.mu.Unlock()
+
+	// Edit to v3 and send with --diff-since-jip.
+	editFile(t, repoDir, changeID, "f.go", "package x\n\nconst V = 3\n")
+	buf.Reset()
+	if err := executeSend(runner, mock, sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, diffSinceJip: true}, &buf); err != nil {
+		t.Fatalf("send 3 failed: %v\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	comments := mock.comments[prNumber]
+	if len(comments) != 1 {
+		t.Fatalf("expected exactly 1 comment from send 3, got %d", len(comments))
+	}
+	comment := comments[0]
+
+	if !strings.Contains(comment, "Changes since last jip send") {
+		t.Errorf("expected jip-specific header, got:\n%s", comment)
+	}
+	// Base is commit1: the diff must show the V=1 -> V=3 transition and the
+	// footer must reference commit1, never commit2.
+	if !strings.Contains(comment, "const V = 1") {
+		t.Errorf("expected diff against commit1 (V=1), got:\n%s", comment)
+	}
+	if !strings.Contains(comment, commit1) {
+		t.Errorf("expected footer to reference base commit1 %s, got:\n%s", commit1, comment)
+	}
+	if strings.Contains(comment, commit2) {
+		t.Errorf("comment should not reference remote head commit2 %s as base:\n%s", commit2, comment)
+	}
+}
+
+// With --diff-since-jip, when the recorded jip commit is not present locally
+// (e.g. pushed from another machine and not fetched), jip documents that the
+// diff could not be generated instead of producing a misleading one.
+func TestIntegration_SendDiffSinceJipCommitNotLocal(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "f.go", "package x\n\nconst V = 1\n", "feat: add f")
+	changeID := getChangeID(t, repoDir, "@-")
+
+	var buf bytes.Buffer
+	if err := executeSend(runner, mock, sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}}, &buf); err != nil {
+		t.Fatalf("send 1 failed: %v\n%s", err, buf.String())
+	}
+
+	var prNumber int
+	mock.mu.Lock()
+	for n := range mock.prs {
+		prNumber = n
+	}
+	// Record a commit that does not exist in the local repo.
+	missing := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	mock.prs[prNumber].Body = gh.WithPushedCommitMarker("feat: add f", missing)
+	mock.comments[prNumber] = nil
+	mock.mu.Unlock()
+
+	editFile(t, repoDir, changeID, "f.go", "package x\n\nconst V = 2\n")
+	buf.Reset()
+	if err := executeSend(runner, mock, sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, diffSinceJip: true}, &buf); err != nil {
+		t.Fatalf("send 2 failed: %v\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	comments := mock.comments[prNumber]
+	if len(comments) != 1 {
+		t.Fatalf("expected exactly 1 comment, got %d", len(comments))
+	}
+	comment := comments[0]
+	if !strings.Contains(comment, "Could not generate") {
+		t.Errorf("expected 'could not generate' note, got:\n%s", comment)
+	}
+	if !strings.Contains(comment, "deadbee") {
+		t.Errorf("expected the missing commit's short hash, got:\n%s", comment)
+	}
+}
+
 func TestIntegration_SendCrossForkPrefixesHead(t *testing.T) {
 	checkJJ(t)
 
@@ -1795,6 +1951,23 @@ func getChangeID(t *testing.T, dir, rev string) string {
 	t.Helper()
 	out := jjRun(t, dir, "log", "--no-graph", "-r", rev, "-T", "change_id")
 	return strings.TrimSpace(out)
+}
+
+func getCommitID(t *testing.T, dir, rev string) string {
+	t.Helper()
+	out := jjRun(t, dir, "log", "--no-graph", "-r", rev, "-T", "commit_id")
+	return strings.TrimSpace(out)
+}
+
+// editFile rewrites a file in an existing change and leaves the working copy on
+// a fresh child so the change resolves as @-.
+func editFile(t *testing.T, dir, changeID, filename, content string) {
+	t.Helper()
+	jjRun(t, dir, "edit", changeID)
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0644); err != nil {
+		t.Fatalf("writing %s: %v", filename, err)
+	}
+	jjRun(t, dir, "new", changeID)
 }
 
 func assertPRRefsInBody(t *testing.T, pr *gh.PRInfo, shouldRef, shouldNotRef []*gh.PRInfo) {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,6 +32,7 @@ Global flags:
 | `--existing` | `-x` | | Only update PRs that already exist (skip new ones) |
 | `--no-stack` | | | Send only the tip of each stack as a single PR |
 | `--rebase` | | | Rebase the stack onto the base branch before sending |
+| `--diff-since-jip` | | | Diff against jip's own last send (recorded in the PR) instead of the current remote head |
 
 ## Revsets
 
@@ -97,6 +98,33 @@ elsewhere (e.g. merging `main` into the `release` branch).
 ```bash
 jip send --no-stack
 ```
+
+## Diffing against jip's last send (`--diff-since-jip`)
+
+When you update a PR, jip posts a "Changes since last push" comment showing what
+changed. By default the comparison is made against the current remote head. If
+someone pushes to the branch directly (without jip), that remote head moves and
+the comparison no longer reflects what reviewers last saw through jip, producing
+an incomplete diff.
+
+`--diff-since-jip` instead compares against the commit jip itself last sent.
+jip records that commit in an invisible marker in the PR body on every send, so
+the base is recovered automatically — the comment header reads "Changes since
+last jip send":
+
+```bash
+jip send --diff-since-jip
+```
+
+If the recorded commit isn't available locally (for example it was pushed from
+another machine and you haven't fetched it), jip can't compute the diff and
+instead posts a note saying so rather than a misleading one. jip writes the
+marker on every send (including `--no-stack` sends), and because each PR carries
+its own marker, this works across an entire stack. A PR only lacks a marker if
+jip has never sent it — for instance a PR created outside jip, or one last sent
+by a jip version predating this feature. In that case jip falls back to
+comparing against the remote head and the comment header reads "Changes since
+last push", not "Changes since last jip send".
 
 ## Authentication
 

--- a/internal/github/prbody.go
+++ b/internal/github/prbody.go
@@ -9,6 +9,123 @@ import (
 // file sections by default.
 const collapseThreshold = 20
 
+// pushedCommitMarkerPrefix is an invisible HTML-comment marker embedded in
+// every PR body by jip. It records the commit jip pushed so that a later
+// `send --diff-since-jip` can recover the previous jip push as the interdiff
+// base, independent of what others pushed to the branch directly.
+const pushedCommitMarkerPrefix = "<!-- jip:pushed-commit="
+
+// pushedCommitMarker renders the marker for the given commit hash.
+func pushedCommitMarker(hash string) string {
+	return pushedCommitMarkerPrefix + hash + " -->"
+}
+
+// WithPushedCommitMarker ensures the PR body contains exactly one pushed-commit
+// marker reflecting commit. If the body already has that exact commit, it is
+// returned unchanged. Otherwise any existing markers are stripped and the new
+// marker is appended.
+func WithPushedCommitMarker(body, commit string) string {
+	if commit == "" {
+		return body
+	}
+	if ParsePushedCommit(body) == commit {
+		return body
+	}
+	body = stripPushedCommitMarkers(body)
+	marker := pushedCommitMarker(commit)
+	if body == "" {
+		return marker
+	}
+	return body + "\n\n" + marker
+}
+
+// stripPushedCommitMarkers removes all pushed-commit markers (and the \n\n
+// separator that WithPushedCommitMarker prepends) from body.
+func stripPushedCommitMarkers(body string) string {
+	for {
+		idx := strings.Index(body, pushedCommitMarkerPrefix)
+		if idx == -1 {
+			break
+		}
+		rest := body[idx+len(pushedCommitMarkerPrefix):]
+		end := strings.Index(rest, "-->")
+		if end == -1 {
+			break
+		}
+		markerEnd := idx + len(pushedCommitMarkerPrefix) + end + len("-->")
+		markerStart := idx
+		if markerStart >= 2 && body[markerStart-2:markerStart] == "\n\n" {
+			markerStart -= 2
+		}
+		body = body[:markerStart] + body[markerEnd:]
+	}
+	return body
+}
+
+// ParsePushedCommit extracts the commit hash from a jip pushed-commit marker
+// in a PR body, or "" if the body has no marker or the value is not a valid
+// hex hash. Uses LastIndex so that if multiple markers exist the newest one
+// wins.
+func ParsePushedCommit(commentBody string) string {
+	idx := strings.LastIndex(commentBody, pushedCommitMarkerPrefix)
+	if idx == -1 {
+		return ""
+	}
+	rest := commentBody[idx+len(pushedCommitMarkerPrefix):]
+	end := strings.Index(rest, "-->")
+	if end == -1 {
+		return ""
+	}
+	value := strings.TrimSpace(rest[:end])
+	if len(value) < 7 {
+		return ""
+	}
+	for i := range len(value) {
+		if !isHexChar(value[i]) {
+			return ""
+		}
+	}
+	return value
+}
+
+// ParseReviewCommit extracts the commit hash from the "Only review commit"
+// link that BuildStackedPRBody writes into a stacked PR's body, or "" if the
+// body has no such link (e.g. a standalone, non-stacked PR).
+//
+// Only the line that starts with "Only review commit" is searched, and the
+// hash is extracted from the exact /pull/<number>/commits/<hash> URL shape to
+// avoid matching unrelated URLs in user-written descriptions.
+func ParseReviewCommit(prBody string) string {
+	const lineMarker = "Only review commit "
+	idx := strings.Index(prBody, lineMarker)
+	if idx == -1 {
+		return ""
+	}
+	// Restrict search to the single line that contains the marker.
+	line := prBody[idx:]
+	if nl := strings.IndexByte(line, '\n'); nl != -1 {
+		line = line[:nl]
+	}
+	const urlMarker = "/commits/"
+	ci := strings.Index(line, urlMarker)
+	if ci == -1 {
+		return ""
+	}
+	rest := line[ci+len(urlMarker):]
+	end := 0
+	for end < len(rest) && isHexChar(rest[end]) {
+		end++
+	}
+	if end < 7 {
+		return ""
+	}
+	return rest[:end]
+}
+
+func isHexChar(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
 // BuildStackBlock generates a markdown stack navigation block showing
 // the current PR's position in the stack.
 func BuildStackBlock(prNumbers []int, current int) string {
@@ -72,18 +189,24 @@ type fileDiff struct {
 }
 
 // BuildDiffComment generates a PR comment with interdiff output,
-// using collapsible sections for each file.
-func BuildDiffComment(codeDiff, repoName, baseBranch, oldCommit, newCommit string) string {
+// using collapsible sections for each file. When sinceJip is true the header
+// reads "Changes since last jip send" (the base is jip's own previous send
+// rather than the current remote head).
+func BuildDiffComment(codeDiff, repoName, baseBranch, oldCommit, newCommit string, sinceJip bool) string {
 	footer := rangeDiffFooter(repoName, baseBranch, oldCommit, newCommit)
+	header := "### Changes since last push\n"
+	if sinceJip {
+		header = "### Changes since last jip send\n"
+	}
 
 	if strings.TrimSpace(codeDiff) == "" {
-		return "### Changes since last push\n\n**No code changes** (likely just a rebase).\n" + footer
+		return header + "\n**No code changes** (likely just a rebase).\n" + footer
 	}
 
 	files := parseGitDiff(codeDiff)
 
 	var b strings.Builder
-	b.WriteString("### Changes since last push\n")
+	b.WriteString(header)
 
 	totalLines := 0
 	for _, f := range files {
@@ -103,6 +226,23 @@ func BuildDiffComment(codeDiff, repoName, baseBranch, oldCommit, newCommit strin
 	}
 
 	b.WriteString(footer)
+	return b.String()
+}
+
+// BuildUnavailableDiffComment generates a PR comment for the case where
+// --diff-since-jip knows the previous jip-pushed commit but cannot find it
+// locally (e.g. it was pushed from another machine and not fetched). It
+// documents that the diff could not be generated and points at the remote.
+func BuildUnavailableDiffComment(repoName, baseBranch, oldCommit, newCommit string) string {
+	oldShort := oldCommit[:minInt(7, len(oldCommit))]
+	var b strings.Builder
+	b.WriteString("### Changes since last jip send\n\n")
+	fmt.Fprintf(&b,
+		"⚠️ Could not generate the diff: the previously pushed commit `%s` is not "+
+			"available locally (it may have been pushed from another machine). "+
+			"Fetch the remote to inspect it.\n",
+		oldShort)
+	b.WriteString(rangeDiffFooter(repoName, baseBranch, oldCommit, newCommit))
 	return b.String()
 }
 

--- a/internal/github/prbody_test.go
+++ b/internal/github/prbody_test.go
@@ -6,6 +6,137 @@ import (
 	"testing"
 )
 
+func TestWithPushedCommitMarker_RoundTrip(t *testing.T) {
+	body := WithPushedCommitMarker("Some description", "abcdef1234567890")
+	if !strings.Contains(body, "Some description") {
+		t.Errorf("marker should not drop the original body, got:\n%s", body)
+	}
+	if got := ParsePushedCommit(body); got != "abcdef1234567890" {
+		t.Errorf("ParsePushedCommit = %q, want %q", got, "abcdef1234567890")
+	}
+}
+
+func TestWithPushedCommitMarker_EmptyBody(t *testing.T) {
+	body := WithPushedCommitMarker("", "abc1234")
+	if got := ParsePushedCommit(body); got != "abc1234" {
+		t.Errorf("ParsePushedCommit = %q, want %q", got, "abc1234")
+	}
+}
+
+func TestParsePushedCommit_InvalidHash(t *testing.T) {
+	for _, bad := range []string{
+		"not-a-hash",          // non-hex chars
+		"abc123",              // too short (< 7)
+		"../../../etc/passwd", // path traversal attempt
+	} {
+		body := pushedCommitMarkerPrefix + bad + " -->"
+		if got := ParsePushedCommit(body); got != "" {
+			t.Errorf("ParsePushedCommit(%q) = %q, want empty", bad, got)
+		}
+	}
+}
+
+func TestParsePushedCommit_MultipleMarkers_LastWins(t *testing.T) {
+	first := pushedCommitMarkerPrefix + "aaaaaaa" + " -->"
+	second := pushedCommitMarkerPrefix + "bbbbbbb" + " -->"
+	body := "some text\n" + first + "\nmore text\n" + second
+	if got := ParsePushedCommit(body); got != "bbbbbbb" {
+		t.Errorf("ParsePushedCommit with multiple markers = %q, want %q", got, "bbbbbbb")
+	}
+}
+
+func TestWithPushedCommitMarker_EmptyCommitIsNoop(t *testing.T) {
+	if got := WithPushedCommitMarker("body", ""); got != "body" {
+		t.Errorf("empty commit should leave body untouched, got %q", got)
+	}
+}
+
+func TestWithPushedCommitMarker_Idempotent(t *testing.T) {
+	body := WithPushedCommitMarker("Some description", "abcdef1234567890")
+	body2 := WithPushedCommitMarker(body, "abcdef1234567890")
+	if body2 != body {
+		t.Errorf("second call with same commit should return body unchanged\ngot:  %q\nwant: %q", body2, body)
+	}
+	if strings.Count(body2, pushedCommitMarkerPrefix) != 1 {
+		t.Errorf("expected exactly one marker, got %d", strings.Count(body2, pushedCommitMarkerPrefix))
+	}
+}
+
+func TestWithPushedCommitMarker_UpdateStripsOldMarker(t *testing.T) {
+	body := WithPushedCommitMarker("Some description", "aaaaaaa")
+	body = WithPushedCommitMarker(body, "bbbbbbb")
+	if strings.Count(body, pushedCommitMarkerPrefix) != 1 {
+		t.Errorf("expected exactly one marker after update, got %d", strings.Count(body, pushedCommitMarkerPrefix))
+	}
+	if got := ParsePushedCommit(body); got != "bbbbbbb" {
+		t.Errorf("ParsePushedCommit = %q, want %q", got, "bbbbbbb")
+	}
+	if !strings.Contains(body, "Some description") {
+		t.Errorf("body should still contain the original description, got: %q", body)
+	}
+}
+
+func TestWithPushedCommitMarker_StripsMultipleOldMarkers(t *testing.T) {
+	// Simulate a body that accumulated markers from previous (pre-fix) sends.
+	body := "desc\n\n" + pushedCommitMarkerPrefix + "aaaaaaa -->\n\n" + pushedCommitMarkerPrefix + "bbbbbbb -->"
+	body = WithPushedCommitMarker(body, "ccccccc")
+	if strings.Count(body, pushedCommitMarkerPrefix) != 1 {
+		t.Errorf("expected exactly one marker, got %d", strings.Count(body, pushedCommitMarkerPrefix))
+	}
+	if got := ParsePushedCommit(body); got != "ccccccc" {
+		t.Errorf("ParsePushedCommit = %q, want %q", got, "ccccccc")
+	}
+}
+
+func TestParsePushedCommit_NoMarker(t *testing.T) {
+	if got := ParsePushedCommit("just a plain body"); got != "" {
+		t.Errorf("expected empty string for body without marker, got %q", got)
+	}
+}
+
+func TestParseReviewCommit_FromStackedBody(t *testing.T) {
+	body := BuildStackedPRBody("abcdef1234567890", "owner/repo", 2, []int{1, 2, 3}, "desc")
+	if got := ParseReviewCommit(body); got != "abcdef1234567890" {
+		t.Errorf("ParseReviewCommit = %q, want %q", got, "abcdef1234567890")
+	}
+}
+
+func TestParseReviewCommit_StandaloneBodyHasNone(t *testing.T) {
+	body := BuildStackedPRBody("abcdef1234567890", "owner/repo", 1, []int{1}, "desc")
+	if got := ParseReviewCommit(body); got != "" {
+		t.Errorf("standalone body has no commit link, got %q", got)
+	}
+}
+
+func TestParseReviewCommit_UnrelatedCommitsURLNotMatched(t *testing.T) {
+	// A /commits/ URL in the user description must not be picked up.
+	body := BuildStackedPRBody("abcdef1234567890", "owner/repo", 2, []int{1, 2, 3},
+		"See https://github.com/other/repo/commits/deadbeefcafe123 for context")
+	if got := ParseReviewCommit(body); got != "abcdef1234567890" {
+		t.Errorf("ParseReviewCommit = %q, want stacked-PR hash %q", got, "abcdef1234567890")
+	}
+}
+
+func TestBuildDiffComment_SinceJipHeader(t *testing.T) {
+	result := BuildDiffComment("", "owner/repo", "main", "aaa111", "bbb222", true)
+	if !strings.Contains(result, "Changes since last jip send") {
+		t.Errorf("expected jip-specific header, got:\n%s", result)
+	}
+}
+
+func TestBuildUnavailableDiffComment(t *testing.T) {
+	result := BuildUnavailableDiffComment("owner/repo", "main", "aaaaaaa1111111", "bbbbbbb2222222")
+	if !strings.Contains(result, "Changes since last jip send") {
+		t.Errorf("expected jip header, got:\n%s", result)
+	}
+	if !strings.Contains(result, "not\navailable locally") && !strings.Contains(result, "not available locally") {
+		t.Errorf("expected explanation that the commit is unavailable, got:\n%s", result)
+	}
+	if !strings.Contains(result, "aaaaaaa") {
+		t.Errorf("expected the missing commit's short hash, got:\n%s", result)
+	}
+}
+
 func TestBuildStackBlock_SinglePR(t *testing.T) {
 	result := BuildStackBlock([]int{1}, 1)
 	if result != "" {
@@ -116,7 +247,7 @@ func TestBuildStackedPRBody_NoStack_EmptyBody(t *testing.T) {
 }
 
 func TestBuildDiffComment_EmptyDiff(t *testing.T) {
-	result := BuildDiffComment("", "owner/repo", "main", "aaa111", "bbb222")
+	result := BuildDiffComment("", "owner/repo", "main", "aaa111", "bbb222", false)
 	if !strings.Contains(result, "Changes since last push") {
 		t.Errorf("expected 'Changes since last push' header, got:\n%s", result)
 	}
@@ -135,7 +266,7 @@ func TestBuildDiffComment_WithDiff(t *testing.T) {
  func Bar() {}
 -// old comment
 `
-	result := BuildDiffComment(diff, "owner/repo", "main", "old1234567890ab", "new4567890abcde")
+	result := BuildDiffComment(diff, "owner/repo", "main", "old1234567890ab", "new4567890abcde", false)
 	if !strings.Contains(result, "Changes since last push") {
 		t.Error("expected 'Changes since last push' header")
 	}
@@ -176,7 +307,7 @@ func TestBuildDiffComment_LargeDiff_CollapsedByDefault(t *testing.T) {
 	}
 	diff := strings.Join(diffLines, "\n")
 
-	result := BuildDiffComment(diff, "owner/repo", "main", "old123", "new456")
+	result := BuildDiffComment(diff, "owner/repo", "main", "old123", "new456", false)
 	if strings.Contains(result, "<details open>") {
 		t.Errorf("expected collapsed details for large diff, got:\n%s", result)
 	}
@@ -186,7 +317,7 @@ func TestBuildDiffComment_LargeDiff_CollapsedByDefault(t *testing.T) {
 }
 
 func TestBuildDiffComment_EmptyDiff_WithFooter(t *testing.T) {
-	result := BuildDiffComment("", "owner/repo", "main", "aaa111222333", "bbb444555666")
+	result := BuildDiffComment("", "owner/repo", "main", "aaa111222333", "bbb444555666", false)
 	if !strings.Contains(result, "View the diff on") {
 		t.Errorf("expected compare link even for empty diff, got:\n%s", result)
 	}
@@ -252,7 +383,7 @@ func TestBuildDiffComment_DiffContainingCodeFences(t *testing.T) {
 +
  ## Configuration
 `
-	result := BuildDiffComment(diff, "owner/repo", "main", "abc1234567890", "def4567890abc")
+	result := BuildDiffComment(diff, "owner/repo", "main", "abc1234567890", "def4567890abc", false)
 
 	// The output must contain the footer (which comes after the diff block).
 	// If triple backticks in the diff prematurely close the fence, the footer

--- a/internal/jj/resolve_integration_test.go
+++ b/internal/jj/resolve_integration_test.go
@@ -329,3 +329,51 @@ func writeAndCommit(t *testing.T, dir, filename, content, message string) {
 	}
 	jjRun(t, dir, "commit", "-m", message)
 }
+
+func getCommitID(t *testing.T, dir, rev string) string {
+	t.Helper()
+	out := jjRun(t, dir, "log", "--no-graph", "-r", rev, "-T", `commit_id ++ "\n"`)
+	return strings.TrimSpace(out)
+}
+
+func TestIntegration_CommitExists_Present(t *testing.T) {
+	dir := initJJRepo(t)
+	runner := NewRunner(dir)
+
+	writeAndCommit(t, dir, "a.txt", "aaa", "a change")
+	commitID := getCommitID(t, dir, "@-")
+
+	exists, err := runner.CommitExists(commitID)
+	if err != nil {
+		t.Fatalf("CommitExists(%q): unexpected error: %v", commitID, err)
+	}
+	if !exists {
+		t.Errorf("CommitExists(%q) = false, want true", commitID)
+	}
+}
+
+func TestIntegration_CommitExists_Absent(t *testing.T) {
+	dir := initJJRepo(t)
+	runner := NewRunner(dir)
+
+	// A well-formed 64-char hex hash that is guaranteed not to be in the repo.
+	absent := strings.Repeat("0", 64)
+
+	exists, err := runner.CommitExists(absent)
+	if err != nil {
+		t.Fatalf("CommitExists on absent hash: unexpected error: %v", err)
+	}
+	if exists {
+		t.Errorf("CommitExists(%q) = true, want false", absent)
+	}
+}
+
+func TestIntegration_CommitExists_BadRepo(t *testing.T) {
+	checkJJ(t)
+	runner := NewRunner("/nonexistent/path/that/cannot/be/a/repo")
+
+	_, err := runner.CommitExists("abcdef1234567")
+	if err == nil {
+		t.Error("CommitExists with bad repo dir: expected error, got nil")
+	}
+}

--- a/internal/jj/runner.go
+++ b/internal/jj/runner.go
@@ -61,6 +61,10 @@ type Runner interface {
 	// Interdiff returns the diff between two revisions using jj interdiff --git.
 	Interdiff(from, to string) (string, error)
 
+	// CommitExists reports whether the given commit/revision is present in the
+	// local repository.
+	CommitExists(rev string) (bool, error)
+
 	// Rebase rebases the given revsets onto the destination revision.
 	Rebase(revsets []string, destination string) error
 
@@ -209,6 +213,40 @@ func (r *realRunner) Interdiff(from, to string) (string, error) {
 	}
 	slog.Debug("jj exec ok", "bytes", len(out))
 	return string(out), nil
+}
+
+func (r *realRunner) CommitExists(rev string) (bool, error) {
+	// Resolve the revision to a single commit. A well-formed hash that isn't in
+	// the repo makes jj exit non-zero with "doesn't exist" / "No commit".
+	args := []string{
+		"log", "--no-graph", "--quiet",
+		"-R", r.repoDir,
+		"-r", rev,
+		"-T", `commit_id ++ "\n"`,
+	}
+	logCmd("jj", args)
+	cmd := exec.Command("jj", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		if isCommitNotFoundError(stderrStr) {
+			slog.Debug("CommitExists: not present locally", "rev", rev, "stderr", stderrStr)
+			return false, nil
+		}
+		slog.Debug("CommitExists: jj failed", "rev", rev, "stderr", stderrStr)
+		return false, fmt.Errorf("jj log %s: %w\n%s", rev, err, stderrStr)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+// isCommitNotFoundError reports whether stderr text from a failed jj log
+// command indicates the revision simply isn't present in the repo (as opposed
+// to an operational failure like a corrupt repo or jj binary issue).
+func isCommitNotFoundError(stderr string) bool {
+	return strings.Contains(stderr, "doesn't exist") ||
+		strings.Contains(stderr, "No commit")
 }
 
 func (r *realRunner) ConfigGet(key string) (string, error) {


### PR DESCRIPTION
- Records pushed commit in an invisible PR-body marker on every send
- --diff-since-jip recovers that marker as the interdiff base, so direct
  pushes by others don't distort the "changes since" comment
- Label the comment header "Changes since last jip send" only when the
  base was actually recovered from a jip record; fall back to the plain
  "Changes since last push" header when no record exists yet

<!-- jip:pushed-commit=1060a4a446b88258ed8449f4d040e9f8f4d6b83b -->