### PR TITLE
feat(send): report up-to-date PRs as skipped, not sent

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -432,6 +432,10 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 	}
 
 	var activeStates, skippedStates []changeState
+	// upToDateCount tracks changes moved to the Skipped section with reason
+	// up-to-date. They are reported as skipped but, unlike real skips, do not
+	// cause a non-zero exit — nothing failed, there was just nothing to do.
+	var upToDateCount int
 	for _, s := range allStates {
 		if _, ok := skippedIDs[s.change.ChangeID]; ok {
 			skippedStates = append(skippedStates, s)
@@ -591,24 +595,41 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 			}
 		}
 
-		// 10. Print summary.
-		_, _ = fmt.Fprintf(w, "\n%d PR(s) sent:\n\n", len(activeStates))
+		// 10. Print summary. PRs that ended up unchanged (branch already up to
+		// date and body already correct) move to the Skipped section with reason
+		// up-to-date — nothing was actually done for them, so reporting them as
+		// "sent" would be noise.
+		var sentStates []changeState
 		for _, s := range activeStates {
-			action := "updated"
-			if s.isNew {
-				action = "created"
-			} else if !s.changed {
-				action = "up-to-date"
+			if s.isNew || s.changed {
+				sentStates = append(sentStates, s)
+			} else {
+				skippedIDs[s.change.ChangeID] = skipReason{reason: "up-to-date"}
+				skippedStates = append(skippedStates, s)
+				upToDateCount++
 			}
-			_, _ = fmt.Fprintf(w, "  #%-4d %s  %s\n", s.pr.Number, action, s.pr.URL)
-			_, _ = fmt.Fprintf(w, "         %.12s  %s\n", s.change.ChangeID, s.change.Title())
+		}
+
+		if len(sentStates) > 0 {
+			_, _ = fmt.Fprintf(w, "\n%d PR(s) sent:\n\n", len(sentStates))
+			for _, s := range sentStates {
+				action := "updated"
+				if s.isNew {
+					action = "created"
+				}
+				_, _ = fmt.Fprintf(w, "  #%-4d %s  %s\n", s.pr.Number, action, s.pr.URL)
+				_, _ = fmt.Fprintf(w, "         %.12s  %s\n", s.change.ChangeID, s.change.Title())
+			}
 		}
 	}
 
 	totalSkipped := len(skippedStates) + len(preSkippedChanges)
 	if totalSkipped > 0 {
 		printAllSkipped(w, skippedStates, skippedIDs, preSkippedChanges)
-		return fmt.Errorf("%d change(s) skipped", totalSkipped)
+	}
+	// Only real skips (not up-to-date) constitute a failure.
+	if realSkipped := totalSkipped - upToDateCount; realSkipped > 0 {
+		return fmt.Errorf("%d change(s) skipped", realSkipped)
 	}
 	return nil
 }

--- a/cmd/send_integration_test.go
+++ b/cmd/send_integration_test.go
@@ -344,8 +344,17 @@ func TestIntegration_SendUpdatesExistingPRs(t *testing.T) {
 		t.Errorf("expected still 1 PR after second send, got %d", len(mock.prs))
 	}
 
-	if !strings.Contains(buf.String(), "up-to-date") {
+	// An unchanged PR is reported as skipped (up-to-date), not as sent, and
+	// does not cause a non-zero exit.
+	out := buf.String()
+	if !strings.Contains(out, "up-to-date") {
 		t.Error("expected 'up-to-date' in second send output")
+	}
+	if !strings.Contains(out, "Skipped 1 change(s)") {
+		t.Errorf("expected up-to-date PR in Skipped section, got:\n%s", out)
+	}
+	if strings.Contains(out, "PR(s) sent") {
+		t.Errorf("expected no 'PR(s) sent' section when only up-to-date, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Unchanged PRs (branch already current and body correct) cluttered the
"PR(s) sent" section with the action up-to-date, implying work was done
when nothing happened. Move them to the Skipped section with reason
up-to-date. They don't count as failures, so an all-up-to-date send still
exits zero.

Closes #16

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- jip:pushed-commit=a071d48cbf7a5572a3e9d261c90ae270db4fd3a7 -->