### PR TITLE
refactor(send): tidy skip reporting

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -242,7 +243,7 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 	}
 	for id := range privateIDs {
 		preSkipIDs[id] = skipReason{
-			reason: "change is private (matches git.private-commits)",
+			reason: "private (matches git.private-commits)",
 		}
 	}
 
@@ -292,7 +293,7 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 		dags = filteredDAGs
 		if len(dags) == 0 && !opts.dryRun {
 			printPreSkippedChanges(w, preSkippedChanges)
-			return fmt.Errorf("%d change(s) skipped — nothing to send", len(preSkippedChanges))
+			return errors.New("changes skipped — nothing to send")
 		}
 	}
 
@@ -466,7 +467,7 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 			printAllSkipped(w, skippedStates, skippedIDs, preSkippedChanges)
 		}
 		if len(skippedStates) > 0 || len(preSkippedChanges) > 0 {
-			return fmt.Errorf("%d change(s) skipped", len(skippedStates)+len(preSkippedChanges))
+			return errors.New("changes skipped")
 		}
 		return nil
 	}
@@ -636,7 +637,7 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 	}
 	// Only real skips (not up-to-date) constitute a failure.
 	if realSkipped := totalSkipped - upToDateCount; realSkipped > 0 {
-		return fmt.Errorf("%d change(s) skipped", realSkipped)
+		return errors.New("changes skipped")
 	}
 	return nil
 }


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [36b7d94](https://github.com/omarkohl/jip/pull/22/commits/36b7d9426844d6ff987f2fea85171629b758224b).

PRs:
* #23
* ➡️ #22 (this PR, base of the stack — can be merged first)

---

## Description

Shorten the private skip reason and drop the redundant skipped-count
from the trailing error — it already appears in the 'Skipped N change(s)'
header.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=36b7d9426844d6ff987f2fea85171629b758224b -->