### PR TITLE
feat(send): add no-change-comment option

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -3,13 +3,17 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/omarkohl/jip/internal/auth"
+	"github.com/omarkohl/jip/internal/config"
 	gh "github.com/omarkohl/jip/internal/github"
 	"github.com/omarkohl/jip/internal/jj"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var sendCmd = &cobra.Command{
@@ -38,6 +42,38 @@ func init() {
 	sendCmd.Flags().Bool("diff-since-jip", false, "Diff against jip's own last send (recorded in the PR) instead of the current remote head, so direct pushes by others don't distort the \"changes since\" comment")
 
 	_ = sendCmd.RegisterFlagCompletionFunc("base", completeJJBookmarks)
+}
+
+// sendConfigKeys lists the send flags that may be set from config files.
+// Per-invocation flags (--dry-run, --existing) are deliberately excluded.
+var sendConfigKeys = map[string]bool{
+	"base":           true,
+	"remote":         true,
+	"upstream":       true,
+	"draft":          true,
+	"no-stack":       true,
+	"rebase":         true,
+	"diff-since-jip": true,
+	"reviewer":       true,
+}
+
+// applySendConfig sets flag values from config files for flags that were not
+// given on the command line, so CLI flags always win.
+func applySendConfig(flags *pflag.FlagSet, cfg map[string]string) error {
+	for _, key := range slices.Sorted(maps.Keys(cfg)) {
+		if !sendConfigKeys[key] {
+			return fmt.Errorf("unsupported config key %q (supported: %s)",
+				key, strings.Join(slices.Sorted(maps.Keys(sendConfigKeys)), ", "))
+		}
+		f := flags.Lookup(key)
+		if f.Changed {
+			continue
+		}
+		if err := flags.Set(key, cfg[key]); err != nil {
+			return fmt.Errorf("config key %q: %w", key, err)
+		}
+	}
+	return nil
 }
 
 // sendOpts holds configuration for the send pipeline.
@@ -83,6 +119,20 @@ type skipReason struct {
 }
 
 func runSend(cmd *cobra.Command, args []string) error {
+	runner, repoRoot, err := workspaceRunner()
+	if err != nil {
+		return err
+	}
+
+	// Apply config file values to flags not set on the command line.
+	cfg, err := config.Load(repoRoot)
+	if err != nil {
+		return err
+	}
+	if err := applySendConfig(cmd.Flags(), cfg); err != nil {
+		return err
+	}
+
 	base, _ := cmd.Flags().GetString("base")
 	remote, _ := cmd.Flags().GetString("remote")
 	upstream, _ := cmd.Flags().GetString("upstream")
@@ -117,11 +167,6 @@ func runSend(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintf(w, "Auth: %s\n", source)
 
 	// 2. Detect repo from remote.
-	runner, _, err := workspaceRunner()
-	if err != nil {
-		return err
-	}
-
 	remoteData, err := runner.GitRemoteList()
 	if err != nil {
 		return fmt.Errorf("listing remotes: %w", err)

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -40,21 +40,25 @@ func init() {
 	sendCmd.Flags().Bool("no-stack", false, "Send only the tip of each stack as a single PR")
 	sendCmd.Flags().Bool("rebase", false, "Rebase the stack onto the base branch before sending")
 	sendCmd.Flags().Bool("diff-since-jip", false, "Diff against jip's own last send (recorded in the PR) instead of the current remote head, so direct pushes by others don't distort the \"changes since\" comment")
+	sendCmd.Flags().String("no-change-comment", "default", "Comment posted when an updated PR has no code changes: default (formatted comment), short (one plain line), or none")
 
 	_ = sendCmd.RegisterFlagCompletionFunc("base", completeJJBookmarks)
+	_ = sendCmd.RegisterFlagCompletionFunc("no-change-comment",
+		cobra.FixedCompletions([]string{"default", "short", "none"}, cobra.ShellCompDirectiveNoFileComp))
 }
 
 // sendConfigKeys lists the send flags that may be set from config files.
 // Per-invocation flags (--dry-run, --existing) are deliberately excluded.
 var sendConfigKeys = map[string]bool{
-	"base":           true,
-	"remote":         true,
-	"upstream":       true,
-	"draft":          true,
-	"no-stack":       true,
-	"rebase":         true,
-	"diff-since-jip": true,
-	"reviewer":       true,
+	"base":              true,
+	"remote":            true,
+	"upstream":          true,
+	"draft":             true,
+	"no-stack":          true,
+	"rebase":            true,
+	"diff-since-jip":    true,
+	"reviewer":          true,
+	"no-change-comment": true,
 }
 
 // applySendConfig sets flag values from config files for flags that were not
@@ -78,19 +82,20 @@ func applySendConfig(flags *pflag.FlagSet, cfg map[string]string) error {
 
 // sendOpts holds configuration for the send pipeline.
 type sendOpts struct {
-	base           string
-	remote         string
-	upstream       string // upstream remote URL (where PRs are opened); empty = same as remote
-	upstreamRemote string // upstream as a named remote (for fetching); empty when upstream is a URL
-	pushOwner      string // owner parsed from push remote (for cross-fork head prefix)
-	dryRun         bool
-	draft          bool
-	existing       bool
-	noStack        bool
-	rebase         bool
-	diffSinceJip   bool
-	reviewers      []string
-	revsets        []string
+	base            string
+	remote          string
+	upstream        string // upstream remote URL (where PRs are opened); empty = same as remote
+	upstreamRemote  string // upstream as a named remote (for fetching); empty when upstream is a URL
+	pushOwner       string // owner parsed from push remote (for cross-fork head prefix)
+	dryRun          bool
+	draft           bool
+	existing        bool
+	noStack         bool
+	rebase          bool
+	diffSinceJip    bool
+	noChangeComment string // "default" (or ""), "short", or "none"
+	reviewers       []string
+	revsets         []string
 }
 
 // skippedEntry records a change that was pre-skipped (before bookmark creation).
@@ -152,6 +157,12 @@ func runSend(cmd *cobra.Command, args []string) error {
 	noStack, _ := cmd.Flags().GetBool("no-stack")
 	rebase, _ := cmd.Flags().GetBool("rebase")
 	diffSinceJip, _ := cmd.Flags().GetBool("diff-since-jip")
+	noChangeComment, _ := cmd.Flags().GetString("no-change-comment")
+	switch noChangeComment {
+	case "default", "short", "none":
+	default:
+		return fmt.Errorf("invalid --no-change-comment value %q (valid: default, short, none)", noChangeComment)
+	}
 	w := cmd.OutOrStdout()
 
 	revsets := args
@@ -213,19 +224,20 @@ func runSend(cmd *cobra.Command, args []string) error {
 	}
 
 	return executeSend(runner, client, sendOpts{
-		base:           base,
-		remote:         remote,
-		upstream:       upstream,
-		upstreamRemote: upstreamRemoteName,
-		pushOwner:      pushOwner,
-		dryRun:         dryRun,
-		draft:          draft,
-		existing:       existing,
-		noStack:        noStack,
-		rebase:         rebase,
-		diffSinceJip:   diffSinceJip,
-		reviewers:      reviewers,
-		revsets:        revsets,
+		base:            base,
+		remote:          remote,
+		upstream:        upstream,
+		upstreamRemote:  upstreamRemoteName,
+		pushOwner:       pushOwner,
+		dryRun:          dryRun,
+		draft:           draft,
+		existing:        existing,
+		noStack:         noStack,
+		rebase:          rebase,
+		diffSinceJip:    diffSinceJip,
+		noChangeComment: noChangeComment,
+		reviewers:       reviewers,
+		revsets:         revsets,
 	}, w)
 }
 
@@ -613,7 +625,7 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 				bi := bookmarkByName[s.bookmark.Bookmark]
 				if bi != nil {
 					if rs, ok := bi.Remotes[opts.remote]; ok {
-						if err := postChangesComment(runner, client, s, rs.Target, repoFullName, baseBranch, opts.diffSinceJip, w); err != nil {
+						if err := postChangesComment(runner, client, s, rs.Target, repoFullName, baseBranch, opts, w); err != nil {
 							return err
 						}
 					}
@@ -722,8 +734,13 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 // When --diff-since-jip resolves the base from a jip record but that commit is
 // not available locally (e.g. another machine pushed it and we didn't fetch),
 // it documents that the diff could not be generated instead of computing one.
-func postChangesComment(runner jj.Runner, client gh.Service, s *changeState, remoteTarget, repoFullName, baseBranch string, sinceJip bool, w io.Writer) error {
+//
+// When the interdiff is empty (e.g. a rebase-only push), opts.noChangeComment
+// controls the comment: "default" posts the formatted no-change comment,
+// "short" a single plain-text line, "none" nothing at all.
+func postChangesComment(runner jj.Runner, client gh.Service, s *changeState, remoteTarget, repoFullName, baseBranch string, opts sendOpts, w io.Writer) error {
 	newCommit := s.change.CommitID
+	sinceJip := opts.diffSinceJip
 
 	base := remoteTarget
 	fromRecord := false
@@ -760,6 +777,22 @@ func postChangesComment(runner jj.Runner, client gh.Service, s *changeState, rem
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "  warning: interdiff failed for #%d: %v\n", s.pr.Number, err)
 		return nil
+	}
+	if strings.TrimSpace(diff) == "" {
+		switch opts.noChangeComment {
+		case "none":
+			return nil
+		case "short":
+			msg := "No changes since last push."
+			if sinceJip && fromRecord {
+				msg = "No changes since last jip send."
+			}
+			if err := client.CommentOnPR(s.pr.Number, msg); err != nil {
+				return fmt.Errorf("commenting on PR #%d: %w", s.pr.Number, err)
+			}
+			s.changed = true
+			return nil
+		}
 	}
 	comment := gh.BuildDiffComment(diff, repoFullName, baseBranch, base, newCommit, sinceJip && fromRecord)
 	if err := client.CommentOnPR(s.pr.Number, comment); err != nil {

--- a/cmd/send_config_test.go
+++ b/cmd/send_config_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// newSendFlags builds a flag set with the same definitions as `jip send`,
+// so config application is tested against the real flag types and defaults.
+func newSendFlags() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("send", pflag.ContinueOnError)
+	sendCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		flags.AddFlag(&pflag.Flag{
+			Name:      f.Name,
+			Shorthand: f.Shorthand,
+			Usage:     f.Usage,
+			Value:     newValueLike(f),
+			DefValue:  f.DefValue,
+		})
+	})
+	return flags
+}
+
+// newValueLike creates a fresh pflag.Value of the same type and default as f,
+// so tests don't mutate the shared sendCmd flag values.
+func newValueLike(f *pflag.Flag) pflag.Value {
+	tmp := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
+	switch f.Value.Type() {
+	case "bool":
+		tmp.Bool(f.Name, f.DefValue == "true", "")
+	case "stringSlice":
+		tmp.StringSlice(f.Name, nil, "")
+	default:
+		tmp.String(f.Name, f.DefValue, "")
+	}
+	return tmp.Lookup(f.Name).Value
+}
+
+func TestApplySendConfig_SetsUnsetFlags(t *testing.T) {
+	flags := newSendFlags()
+	cfg := map[string]string{
+		"rebase":   "true",
+		"base":     "dev",
+		"reviewer": "alice,team/backend",
+	}
+	if err := applySendConfig(flags, cfg); err != nil {
+		t.Fatalf("applySendConfig: %v", err)
+	}
+	if got := flags.Lookup("rebase").Value.String(); got != "true" {
+		t.Errorf("rebase = %q, want true", got)
+	}
+	if got := flags.Lookup("base").Value.String(); got != "dev" {
+		t.Errorf("base = %q, want dev", got)
+	}
+	if got := flags.Lookup("reviewer").Value.String(); got != "[alice,team/backend]" {
+		t.Errorf("reviewer = %q, want [alice,team/backend]", got)
+	}
+}
+
+func TestApplySendConfig_CLIFlagWins(t *testing.T) {
+	flags := newSendFlags()
+	if err := flags.Set("base", "release"); err != nil {
+		t.Fatal(err)
+	}
+	if err := applySendConfig(flags, map[string]string{"base": "dev"}); err != nil {
+		t.Fatalf("applySendConfig: %v", err)
+	}
+	if got := flags.Lookup("base").Value.String(); got != "release" {
+		t.Errorf("base = %q, want release (CLI must override config)", got)
+	}
+}
+
+func TestApplySendConfig_UnknownKey(t *testing.T) {
+	flags := newSendFlags()
+	err := applySendConfig(flags, map[string]string{"dry-run": "true"})
+	if err == nil {
+		t.Fatal("expected error for unsupported key")
+	}
+	if !strings.Contains(err.Error(), "dry-run") {
+		t.Errorf("error should name the key, got: %v", err)
+	}
+}
+
+func TestApplySendConfig_InvalidValue(t *testing.T) {
+	flags := newSendFlags()
+	err := applySendConfig(flags, map[string]string{"rebase": "yes"})
+	if err == nil {
+		t.Fatal("expected error for invalid boolean value")
+	}
+	if !strings.Contains(err.Error(), "rebase") {
+		t.Errorf("error should name the key, got: %v", err)
+	}
+}
+
+// Every key allowed in config must correspond to an actual send flag.
+func TestSendConfigKeys_MatchFlags(t *testing.T) {
+	for key := range sendConfigKeys {
+		if sendCmd.Flags().Lookup(key) == nil {
+			t.Errorf("config key %q has no matching send flag", key)
+		}
+	}
+}

--- a/cmd/send_integration_test.go
+++ b/cmd/send_integration_test.go
@@ -580,6 +580,110 @@ func TestIntegration_SendPostsInterdiffComment(t *testing.T) {
 	}
 }
 
+// setupNoChangeResend creates a PR via a first send, then rebases the change
+// onto an advanced main without touching its content, so a second send pushes
+// a new commit whose interdiff is empty (a rebase-only update).
+func setupNoChangeResend(t *testing.T) (jj.Runner, *mockService, int) {
+	t.Helper()
+
+	mock := newMockService()
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "handler.go", "package api", "feat: add request handler")
+	changeID := getChangeID(t, repoDir, "@-")
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:    "main",
+		remote:  "origin",
+		revsets: []string{"@-"},
+	}, &buf)
+	if err != nil {
+		t.Fatalf("first send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	if len(mock.prs) != 1 {
+		mock.mu.Unlock()
+		t.Fatalf("expected 1 PR after first send, got %d", len(mock.prs))
+	}
+	var prNumber int
+	for n := range mock.prs {
+		prNumber = n
+	}
+	mock.mu.Unlock()
+
+	// Advance main with an unrelated change and rebase our change onto it.
+	// The commit ID changes (so the bookmark is pushed again) but the
+	// interdiff is empty.
+	jjRun(t, repoDir, "new", "main")
+	writeAndCommit(t, repoDir, "other.go", "package other", "feat: unrelated change on main")
+	jjRun(t, repoDir, "bookmark", "set", "main", "-r", "@-")
+	jjRun(t, repoDir, "git", "push", "--bookmark", "main")
+	jjRun(t, repoDir, "rebase", "-r", changeID, "-d", "main")
+	jjRun(t, repoDir, "new", changeID)
+
+	return runner, mock, prNumber
+}
+
+// noChangeResend runs the second send after setupNoChangeResend and returns
+// the comments posted on the PR.
+func noChangeResend(t *testing.T, runner jj.Runner, mock *mockService, prNumber int, noChangeComment string) []string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:            "main",
+		remote:          "origin",
+		revsets:         []string{"@-"},
+		noChangeComment: noChangeComment,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("second send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	return mock.comments[prNumber]
+}
+
+func TestIntegration_SendNoChangeCommentDefault(t *testing.T) {
+	checkJJ(t)
+	runner, mock, prNumber := setupNoChangeResend(t)
+
+	comments := noChangeResend(t, runner, mock, prNumber, "default")
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d: %v", len(comments), comments)
+	}
+	if !strings.Contains(comments[0], "No code changes") {
+		t.Errorf("expected formatted no-change comment, got:\n%s", comments[0])
+	}
+}
+
+func TestIntegration_SendNoChangeCommentShort(t *testing.T) {
+	checkJJ(t)
+	runner, mock, prNumber := setupNoChangeResend(t)
+
+	comments := noChangeResend(t, runner, mock, prNumber, "short")
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d: %v", len(comments), comments)
+	}
+	if comments[0] != "No changes since last push." {
+		t.Errorf("expected short plain-text comment, got:\n%s", comments[0])
+	}
+}
+
+func TestIntegration_SendNoChangeCommentNone(t *testing.T) {
+	checkJJ(t)
+	runner, mock, prNumber := setupNoChangeResend(t)
+
+	comments := noChangeResend(t, runner, mock, prNumber, "none")
+	if len(comments) != 0 {
+		t.Errorf("expected no comments, got %d: %v", len(comments), comments)
+	}
+}
+
 // After any send, the PR body should carry the invisible pushed-commit marker
 // recording the commit that was pushed, so a later --diff-since-jip can use it.
 func TestIntegration_SendEmbedsPushedCommitMarker(t *testing.T) {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -34,6 +34,35 @@ Global flags:
 | `--rebase` | | | Rebase the stack onto the base branch before sending |
 | `--diff-since-jip` | | | Diff against jip's own last send (recorded in the PR) instead of the current remote head |
 
+## Configuration files
+
+Workflow preferences can be set persistently instead of being passed as flags
+on every invocation. jip reads two TOML files:
+
+1. **Global** — `~/.config/jip/config.toml` (the platform's user config dir,
+   e.g. `$XDG_CONFIG_HOME/jip/config.toml`)
+2. **Repo** — `.jip.toml` in the repository root (commit it to share team
+   defaults)
+
+Repo values override global values; CLI flags override both.
+
+Keys mirror the `send` flag names: `base`, `remote`, `upstream`, `draft`,
+`no-stack`, `rebase`, `diff-since-jip`, `reviewer`. Per-invocation flags
+(`--dry-run`, `--existing`) cannot be set from config.
+
+```toml
+# ~/.config/jip/config.toml — personal preferences
+rebase = true
+diff-since-jip = true
+```
+
+```toml
+# .jip.toml (repo root) — team defaults
+base = "dev"
+draft = true
+reviewer = ["alice", "team/backend"]
+```
+
 ## Revsets
 
 `send` takes optional revset arguments to select which changes to send. The

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -33,6 +33,7 @@ Global flags:
 | `--no-stack` | | | Send only the tip of each stack as a single PR |
 | `--rebase` | | | Rebase the stack onto the base branch before sending |
 | `--diff-since-jip` | | | Diff against jip's own last send (recorded in the PR) instead of the current remote head |
+| `--no-change-comment` | | `default` | Comment posted when an updated PR has no code changes: `default`, `short`, or `none` |
 
 ## Configuration files
 
@@ -47,8 +48,8 @@ on every invocation. jip reads two TOML files:
 Repo values override global values; CLI flags override both.
 
 Keys mirror the `send` flag names: `base`, `remote`, `upstream`, `draft`,
-`no-stack`, `rebase`, `diff-since-jip`, `reviewer`. Per-invocation flags
-(`--dry-run`, `--existing`) cannot be set from config.
+`no-stack`, `rebase`, `diff-since-jip`, `reviewer`, `no-change-comment`.
+Per-invocation flags (`--dry-run`, `--existing`) cannot be set from config.
 
 ```toml
 # ~/.config/jip/config.toml — personal preferences
@@ -154,6 +155,24 @@ jip has never sent it — for instance a PR created outside jip, or one last sen
 by a jip version predating this feature. In that case jip falls back to
 comparing against the remote head and the comment header reads "Changes since
 last push", not "Changes since last jip send".
+
+## No-change comments (`--no-change-comment`)
+
+When an updated PR contains no code changes (e.g. it was only rebased), jip
+posts a comment noting that. That signal distinguishes a jip send from a
+direct force-push made outside jip, but repeat occurrences add noise for
+reviewers. `--no-change-comment` controls the behavior:
+
+- `default` — the usual formatted comment ("No code changes …")
+- `short` — a single plain-text line: `No changes since last push.`
+- `none` — no comment at all
+
+```bash
+jip send --no-change-comment=short
+```
+
+Like other workflow preferences, this can be set persistently in a
+[config file](#configuration-files).
 
 ## Authentication
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -68,6 +68,10 @@ If a PR was only rebased without any actual content changes, jip notes that:
 
 ![Comment indicating the PR was only rebased with no content changes](images/rebase-only-comment.png)
 
+If these comments are too noisy for your team, the `--no-change-comment`
+option can shorten or suppress them (see the
+[command reference](reference.md#no-change-comments---no-change-comment)).
+
 ## Merging
 
 PRs created by jip are **normal GitHub PRs**. There is no special "land"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/cli/browser v1.3.0 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cli/browser v1.0.0/go.mod h1:IEWkHYbLjkhtjwwWlwTHW2lGxeS5gezEQBMLTwDHf5Q=
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,119 @@
+// Package config loads jip's persistent preferences from TOML config files.
+//
+// Two locations are consulted, in order:
+//  1. Global: <user config dir>/jip/config.toml (e.g. ~/.config/jip/config.toml)
+//  2. Repo:   .jip.toml in the repository root
+//
+// Repo values override global values. CLI flags override both (enforced by
+// the caller, which only applies config to flags not set on the command line).
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Dir overrides the global config directory for testing.
+// If empty, os.UserConfigDir() is used.
+var Dir string
+
+// GlobalPath returns the path of the global config file.
+func GlobalPath() (string, error) {
+	dir := Dir
+	if dir == "" {
+		var err error
+		dir, err = os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(dir, "jip", "config.toml"), nil
+}
+
+// Load reads the global and repo config files and returns a merged key→value
+// map with repo values taking precedence. Values are normalized to strings
+// ready to be applied to command-line flags (arrays are joined with commas).
+// Missing files are not an error; repoRoot may be empty to skip the repo file.
+func Load(repoRoot string) (map[string]string, error) {
+	merged := make(map[string]string)
+
+	// The global config is an optional convenience: if its location can't be
+	// determined (e.g. os.UserConfigDir() fails because $HOME is unset),
+	// proceed as if there were no global config rather than aborting.
+	if globalPath, err := GlobalPath(); err == nil {
+		global, err := loadFile(globalPath)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range global {
+			merged[k] = v
+		}
+	}
+
+	if repoRoot != "" {
+		repo, err := loadFile(filepath.Join(repoRoot, ".jip.toml"))
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range repo {
+			merged[k] = v
+		}
+	}
+	return merged, nil
+}
+
+// loadFile parses a single TOML config file into flag-ready string values.
+// A missing file yields an empty map.
+func loadFile(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("reading config %s: %w", path, err)
+	}
+
+	var raw map[string]any
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing config %s: %w", path, err)
+	}
+
+	cfg := make(map[string]string, len(raw))
+	for key, val := range raw {
+		s, err := stringify(val)
+		if err != nil {
+			return nil, fmt.Errorf("config %s: key %q: %w", path, key, err)
+		}
+		cfg[key] = s
+	}
+	return cfg, nil
+}
+
+// stringify converts a TOML value to a flag-ready string.
+func stringify(val any) (string, error) {
+	switch v := val.(type) {
+	case string:
+		return v, nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	case int64:
+		return strconv.FormatInt(v, 10), nil
+	case []any:
+		parts := make([]string, len(v))
+		for i, e := range v {
+			s, ok := e.(string)
+			if !ok {
+				return "", fmt.Errorf("array elements must be strings, got %T", e)
+			}
+			parts[i] = s
+		}
+		return strings.Join(parts, ","), nil
+	default:
+		return "", fmt.Errorf("unsupported value type %T (use a string, boolean, integer, or array of strings)", val)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setGlobalConfig points the global config dir at a temp dir and writes the
+// given config.toml content (skipped when content is empty).
+func setGlobalConfig(t *testing.T, content string) {
+	t.Helper()
+	dir := t.TempDir()
+	old := Dir
+	Dir = dir
+	t.Cleanup(func() { Dir = old })
+	if content != "" {
+		jipDir := filepath.Join(dir, "jip")
+		if err := os.MkdirAll(jipDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(jipDir, "config.toml"), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// writeRepoConfig creates a temp repo root containing a .jip.toml.
+func writeRepoConfig(t *testing.T, content string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".jip.toml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestLoad_MissingFiles(t *testing.T) {
+	setGlobalConfig(t, "")
+	cfg, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg) != 0 {
+		t.Errorf("expected empty config, got %v", cfg)
+	}
+}
+
+func TestLoad_RepoOverridesGlobal(t *testing.T) {
+	setGlobalConfig(t, "rebase = true\nbase = \"main\"\n")
+	root := writeRepoConfig(t, "base = \"dev\"\ndraft = true\n")
+
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]string{
+		"rebase": "true", // global only
+		"base":   "dev",  // repo overrides global
+		"draft":  "true", // repo only
+	}
+	for k, v := range want {
+		if cfg[k] != v {
+			t.Errorf("cfg[%q] = %q, want %q", k, cfg[k], v)
+		}
+	}
+}
+
+func TestLoad_ValueTypes(t *testing.T) {
+	setGlobalConfig(t, "")
+	root := writeRepoConfig(t, `
+rebase = true
+base = "dev"
+reviewer = ["alice", "team/backend"]
+`)
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg["rebase"] != "true" {
+		t.Errorf("rebase = %q, want %q", cfg["rebase"], "true")
+	}
+	if cfg["base"] != "dev" {
+		t.Errorf("base = %q, want %q", cfg["base"], "dev")
+	}
+	if cfg["reviewer"] != "alice,team/backend" {
+		t.Errorf("reviewer = %q, want %q", cfg["reviewer"], "alice,team/backend")
+	}
+}
+
+// TestLoad_GlobalConfigDirUnresolvable simulates an environment where
+// os.UserConfigDir() cannot resolve a directory (e.g. $HOME unset in a
+// minimal container). Load should degrade to "no global config" instead of
+// failing outright, since the global config is optional.
+func TestLoad_GlobalConfigDirUnresolvable(t *testing.T) {
+	old := Dir
+	Dir = ""
+	t.Cleanup(func() { Dir = old })
+
+	for _, key := range []string{"HOME", "XDG_CONFIG_HOME", "APPDATA"} {
+		if val, ok := os.LookupEnv(key); ok {
+			if err := os.Unsetenv(key); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := os.Setenv(key, val); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+	}
+
+	if _, err := os.UserConfigDir(); err == nil {
+		t.Skip("os.UserConfigDir() did not fail with env vars unset; cannot simulate on this platform")
+	}
+
+	root := writeRepoConfig(t, "base = \"dev\"\n")
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg["base"] != "dev" {
+		t.Errorf("base = %q, want %q", cfg["base"], "dev")
+	}
+}
+
+func TestLoad_InvalidTOML(t *testing.T) {
+	setGlobalConfig(t, "")
+	root := writeRepoConfig(t, "rebase = \n")
+	_, err := Load(root)
+	if err == nil {
+		t.Fatal("expected error for invalid TOML")
+	}
+	if !strings.Contains(err.Error(), ".jip.toml") {
+		t.Errorf("error should name the file, got: %v", err)
+	}
+}
+
+func TestLoad_UnsupportedValueType(t *testing.T) {
+	setGlobalConfig(t, "")
+	root := writeRepoConfig(t, "[section]\nkey = \"value\"\n")
+	_, err := Load(root)
+	if err == nil {
+		t.Fatal("expected error for nested table")
+	}
+}


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [527d62c](https://github.com/omarkohl/jip/pull/27/commits/527d62cdfc6c9623cabea2fe4fce314895745c0d).

PRs:
* ➡️ #27 (this PR, depends on the ones below ⬇️)
* #26

---

## Description

Repeated "no code changes" comments on rebase-only updates add noise
for reviewers, but suppressing them entirely would make a jip send
indistinguishable from a force-push made outside jip. Let users pick
the trade-off: default (formatted comment), short (one plain line),
or none — via --no-change-comment or the config files.

Closes #20

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=527d62cdfc6c9623cabea2fe4fce314895745c0d -->