### PR TITLE
fix(send): work when run from a repo subdirectory

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -117,11 +117,10 @@ func runSend(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintf(w, "Auth: %s\n", source)
 
 	// 2. Detect repo from remote.
-	cwd, err := os.Getwd()
+	runner, _, err := workspaceRunner()
 	if err != nil {
-		return fmt.Errorf("getting cwd: %w", err)
+		return err
 	}
-	runner := jj.NewRunner(cwd)
 
 	remoteData, err := runner.GitRemoteList()
 	if err != nil {
@@ -183,6 +182,26 @@ func runSend(cmd *cobra.Command, args []string) error {
 		reviewers:      reviewers,
 		revsets:        revsets,
 	}, w)
+}
+
+// workspaceRunner locates the jj workspace containing the current working
+// directory and returns a Runner anchored at its root, plus the root path.
+// jj's -R flag does not search parent directories, so anchoring the runner at
+// the workspace root (rather than the cwd) is what lets jip run from a
+// subdirectory of the repository.
+func workspaceRunner() (jj.Runner, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, "", fmt.Errorf("getting cwd: %w", err)
+	}
+	root, err := jj.WorkspaceRoot(cwd)
+	if err != nil {
+		return nil, "", err
+	}
+	if root == "" {
+		return nil, "", fmt.Errorf("%s is not in a jj repository", cwd)
+	}
+	return jj.NewRunner(root), root, nil
 }
 
 // executeSend runs the core send algorithm: resolve stacks, ensure bookmarks,

--- a/cmd/send_integration_test.go
+++ b/cmd/send_integration_test.go
@@ -1898,6 +1898,55 @@ func (s *spyRunner) Rebase(revsets []string, destination string) error {
 	return s.Runner.Rebase(revsets, destination)
 }
 
+func TestIntegration_WorkspaceRunnerFromSubdirectory(t *testing.T) {
+	checkJJ(t)
+
+	repoDir, _ := initTestRepoWithRemote(t)
+	sub := filepath.Join(repoDir, "sub", "dir")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+
+	runner, root, err := workspaceRunner()
+	if err != nil {
+		t.Fatalf("workspaceRunner from subdirectory: %v", err)
+	}
+
+	// jj canonicalizes the root path, so compare with symlinks resolved.
+	wantRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Errorf("root = %q, want %q", root, repoDir)
+	}
+
+	// The runner must work from the subdirectory: jj -R does not search
+	// parent directories, so a runner anchored at the cwd would fail here.
+	if _, err := runner.BookmarkList(); err != nil {
+		t.Errorf("runner from subdirectory: %v", err)
+	}
+}
+
+func TestIntegration_WorkspaceRunnerOutsideRepo(t *testing.T) {
+	checkJJ(t)
+
+	t.Chdir(t.TempDir())
+
+	_, _, err := workspaceRunner()
+	if err == nil {
+		t.Fatal("expected error outside a jj repository")
+	}
+	if !strings.Contains(err.Error(), "not in a jj repository") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 // --- Test helpers ---
 
 func checkJJ(t *testing.T) {

--- a/internal/jj/runner.go
+++ b/internal/jj/runner.go
@@ -78,6 +78,27 @@ func NewRunner(repoDir string) Runner {
 	return &realRunner{repoDir: repoDir}
 }
 
+// WorkspaceRoot returns the root directory of the jj workspace containing
+// dir, or "" if dir is not inside a jj workspace. It runs `jj root` with dir
+// as the working directory because -R does not search parent directories.
+func WorkspaceRoot(dir string) (string, error) {
+	args := []string{"root"}
+	logCmd("jj", args)
+	cmd := exec.Command("jj", args...)
+	cmd.Dir = dir
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		if strings.Contains(stderrStr, "no jj repo") {
+			return "", nil
+		}
+		return "", fmt.Errorf("jj root: %w\n%s", err, stderrStr)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 type realRunner struct {
 	repoDir string
 }

--- a/internal/jj/runner_integration_test.go
+++ b/internal/jj/runner_integration_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package jj
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIntegration_WorkspaceRoot(t *testing.T) {
+	dir := initJJRepo(t)
+
+	sub := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// jj canonicalizes the root path, so compare with symlinks resolved
+	// (e.g. /tmp vs /private/tmp on macOS).
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, from := range []string{dir, sub} {
+		got, err := WorkspaceRoot(from)
+		if err != nil {
+			t.Fatalf("WorkspaceRoot(%q): %v", from, err)
+		}
+		resolved, err := filepath.EvalSymlinks(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resolved != want {
+			t.Errorf("WorkspaceRoot(%q) = %q, want %q", from, got, want)
+		}
+	}
+
+	got, err := WorkspaceRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("WorkspaceRoot outside a repo: %v", err)
+	}
+	if got != "" {
+		t.Errorf("WorkspaceRoot outside a repo = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [9990c9b](https://github.com/omarkohl/jip/pull/28/commits/9990c9b14a2d47626a92d66ff2a20391027a4882).

PRs:
* #27
* #26
* ➡️ #28 (this PR, base of the stack — can be merged first)

---

## Description

Every jj command was invoked with -R <cwd>, but -R does not search parent
directories, so send failed anywhere below the repo root. Resolve the
workspace root via 'jj root' and anchor the runner there.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=9990c9b14a2d47626a92d66ff2a20391027a4882 -->