### PR TITLE
feat(send): support GitHub native stacked PRs via --stack=gh-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ request. When you update a PR, jip posts a comment showing what you changed
 - **Supports forks** — works both for repositories where you have write access as well as forked ones
 - **Normal GitHub merge** — no special "land" command, just merge PRs as usual
 - **Stacks may contain merge commits** — supports non-linear revision graphs
+- **Optional GitHub native stacked PRs** — with `--stack=gh-native`, jip links
+  PRs into GitHub's built-in stacks (private preview) instead of rendering
+  stack navigation into descriptions ([details](docs/reference.md#stacking-modes---stack))
 
 ## Installation
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -23,7 +23,11 @@ var sendCmd = &cobra.Command{
 	Long: `Send creates or updates GitHub pull requests for each change in the
 resolved stack. Each change gets its own PR targeting the base branch.
 
-Default revset is @- (the last committed change and its ancestors up to base).`,
+Default revset is @- (the last committed change and its ancestors up to base).
+
+The --stack flag selects how stacks are represented: navigation rendered into
+PR descriptions (default), GitHub's native stacked PRs (gh-native, requires
+preview access), or a single PR for the stack tip (none).`,
 	RunE:              runSend,
 	ValidArgsFunction: completeJJRevsets,
 }
@@ -37,7 +41,9 @@ func init() {
 	sendCmd.Flags().StringSliceP("reviewer", "r", nil, "Add reviewers (repeatable, comma-separated)")
 	sendCmd.Flags().BoolP("draft", "d", false, "Create PRs as drafts")
 	sendCmd.Flags().BoolP("existing", "x", false, "Only update PRs that already exist (skip new ones)")
+	sendCmd.Flags().String("stack", stackModeDefault, "Stacking mode: default (stack navigation in PR descriptions), gh-native (GitHub's native stacked PRs, requires preview access), or none (send only the tip of each stack as a single PR)")
 	sendCmd.Flags().Bool("no-stack", false, "Send only the tip of each stack as a single PR")
+	_ = sendCmd.Flags().MarkDeprecated("no-stack", "use --stack=none")
 	sendCmd.Flags().Bool("rebase", false, "Rebase the stack onto the base branch before sending")
 	sendCmd.Flags().Bool("diff-since-jip", false, "Diff against jip's own last send (recorded in the PR) instead of the current remote head, so direct pushes by others don't distort the \"changes since\" comment")
 	sendCmd.Flags().String("no-change-comment", "default", "Comment posted when an updated PR has no code changes: default (formatted comment), short (one plain line), or none")
@@ -45,7 +51,16 @@ func init() {
 	_ = sendCmd.RegisterFlagCompletionFunc("base", completeJJBookmarks)
 	_ = sendCmd.RegisterFlagCompletionFunc("no-change-comment",
 		cobra.FixedCompletions([]string{"default", "short", "none"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = sendCmd.RegisterFlagCompletionFunc("stack",
+		cobra.FixedCompletions([]string{stackModeDefault, stackModeNative, stackModeNone}, cobra.ShellCompDirectiveNoFileComp))
 }
+
+// Stacking modes for the --stack flag.
+const (
+	stackModeDefault = "default"   // stack navigation rendered into PR descriptions
+	stackModeNative  = "gh-native" // GitHub's native stacked PRs (private preview)
+	stackModeNone    = "none"      // single PR per stack tip, no stacking
+)
 
 // sendConfigKeys lists the send flags that may be set from config files.
 // Per-invocation flags (--dry-run, --existing) are deliberately excluded.
@@ -54,6 +69,7 @@ var sendConfigKeys = map[string]bool{
 	"remote":            true,
 	"upstream":          true,
 	"draft":             true,
+	"stack":             true,
 	"no-stack":          true,
 	"rebase":            true,
 	"diff-since-jip":    true,
@@ -80,6 +96,24 @@ func applySendConfig(flags *pflag.FlagSet, cfg map[string]string) error {
 	return nil
 }
 
+// resolveStackMode reconciles the --stack flag with the deprecated --no-stack.
+// CLI flags beat config values: --no-stack on the command line overrides a
+// config-supplied stack key, while an explicit --stack overrides a
+// config-supplied no-stack. stackSet reports whether --stack was set at all
+// (CLI or config); noStackOnCLI whether --no-stack was given on the CLI.
+func resolveStackMode(stack string, stackSet, noStack, noStackOnCLI bool) (string, error) {
+	switch stack {
+	case stackModeDefault, stackModeNative, stackModeNone:
+	default:
+		return "", fmt.Errorf("invalid --stack value %q (valid: %s, %s, %s)",
+			stack, stackModeDefault, stackModeNative, stackModeNone)
+	}
+	if noStack && (noStackOnCLI || !stackSet) {
+		return stackModeNone, nil
+	}
+	return stack, nil
+}
+
 // sendOpts holds configuration for the send pipeline.
 type sendOpts struct {
 	base            string
@@ -90,7 +124,7 @@ type sendOpts struct {
 	dryRun          bool
 	draft           bool
 	existing        bool
-	noStack         bool
+	stackMode       string // stackModeDefault (or ""), stackModeNative, or stackModeNone
 	rebase          bool
 	diffSinceJip    bool
 	noChangeComment string // "default" (or ""), "short", or "none"
@@ -129,6 +163,14 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Record which stack flags came from the command line before config
+	// application marks config-supplied flags as changed too.
+	stackOnCLI := cmd.Flags().Changed("stack")
+	noStackOnCLI := cmd.Flags().Changed("no-stack")
+	if stackOnCLI && noStackOnCLI {
+		return fmt.Errorf("--no-stack is deprecated and cannot be combined with --stack (use --stack=none)")
+	}
+
 	// Apply config file values to flags not set on the command line.
 	cfg, err := config.Load(repoRoot)
 	if err != nil {
@@ -154,7 +196,12 @@ func runSend(cmd *cobra.Command, args []string) error {
 	reviewers = cleanReviewers
 	draft, _ := cmd.Flags().GetBool("draft")
 	existing, _ := cmd.Flags().GetBool("existing")
+	stackFlag, _ := cmd.Flags().GetString("stack")
 	noStack, _ := cmd.Flags().GetBool("no-stack")
+	stackMode, err := resolveStackMode(stackFlag, cmd.Flags().Changed("stack"), noStack, noStackOnCLI)
+	if err != nil {
+		return err
+	}
 	rebase, _ := cmd.Flags().GetBool("rebase")
 	diffSinceJip, _ := cmd.Flags().GetBool("diff-since-jip")
 	noChangeComment, _ := cmd.Flags().GetString("no-change-comment")
@@ -232,7 +279,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		dryRun:          dryRun,
 		draft:           draft,
 		existing:        existing,
-		noStack:         noStack,
+		stackMode:       stackMode,
 		rebase:          rebase,
 		diffSinceJip:    diffSinceJip,
 		noChangeComment: noChangeComment,
@@ -264,6 +311,25 @@ func workspaceRunner() (jj.Runner, string, error) {
 // executeSend runs the core send algorithm: resolve stacks, ensure bookmarks,
 // push branches, and create/update PRs.
 func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer) error {
+	if opts.stackMode == "" {
+		opts.stackMode = stackModeDefault
+	}
+
+	// gh-native mode: fail fast, before mutating anything.
+	if opts.stackMode == stackModeNative {
+		if opts.upstream != "" {
+			return fmt.Errorf("--stack=gh-native does not support --upstream: GitHub native stacks cannot span forks")
+		}
+		enabled, err := client.StacksEnabled()
+		if err != nil {
+			return err
+		}
+		if !enabled {
+			return fmt.Errorf("GitHub native stacked PRs are not enabled for %s/%s — the feature is a private preview (https://gh.io/stacksbeta); use --stack=default until the repository is enrolled",
+				client.Owner(), client.Repo())
+		}
+	}
+
 	// Fetch from remote (and upstream if it's a named remote).
 	_, _ = fmt.Fprintf(w, "Fetching %s...\n", opts.remote)
 	if err := runner.GitFetch(opts.remote); err != nil {
@@ -296,12 +362,12 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 		return nil
 	}
 
-	// If --no-stack, reduce each DAG to its tip (leaf) change only.
-	if opts.noStack {
+	// If --stack=none, reduce each DAG to its tip (leaf) change only.
+	if opts.stackMode == stackModeNone {
 		for i, dag := range dags {
 			leaves := dag.LeafChanges()
 			if len(leaves) != 1 {
-				return fmt.Errorf("--no-stack requires a linear stack (found %d tips in one DAG)", len(leaves))
+				return fmt.Errorf("--stack=none requires a linear stack (found %d tips in one DAG)", len(leaves))
 			}
 			tip := leaves[0]
 			dags[i] = &jj.ChangeDAG{
@@ -531,6 +597,14 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 		}
 	}
 
+	// GitHub native stacks cannot express branching or merging dependency
+	// graphs — each stack must be a single linear chain.
+	if opts.stackMode == stackModeNative {
+		if err := checkLinearStacks(activeStates); err != nil {
+			return err
+		}
+	}
+
 	if opts.dryRun {
 		_, _ = fmt.Fprintf(w, "\nDry run — %d change(s) would be sent:\n\n", len(activeStates))
 		for _, s := range activeStates {
@@ -544,6 +618,9 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 			}
 			_, _ = fmt.Fprintf(w, "  %s  %.12s  %s\n", action, s.change.ChangeID, s.change.Title())
 			_, _ = fmt.Fprintf(w, "         bookmark: %s (%s)\n", s.bookmark.Bookmark, bmStatus)
+		}
+		if opts.stackMode == stackModeNative && len(activeStates) > 1 {
+			_, _ = fmt.Fprintf(w, "\nPRs would be linked into native GitHub stack(s).\n")
 		}
 		if len(skippedStates) > 0 || len(preSkippedChanges) > 0 {
 			printAllSkipped(w, skippedStates, skippedIDs, preSkippedChanges)
@@ -606,6 +683,36 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 
 	if len(activeStates) > 0 {
 		// 8. Create/update PRs.
+		//
+		// In gh-native mode each PR targets the branch of the change below it
+		// (GitHub's stack API requires a valid base-to-head chain); otherwise
+		// every PR targets the base branch.
+		groups := stackGroups(activeStates)
+		desiredBase := make(map[string]string, len(activeStates))
+		activeBookmarks := make(map[string]bool, len(activeStates))
+		for _, group := range groups {
+			prev := baseBranch
+			for _, s := range group {
+				desiredBase[s.change.ChangeID] = prev
+				activeBookmarks[s.bookmark.Bookmark] = true
+				if opts.stackMode == stackModeNative {
+					prev = s.bookmark.Bookmark
+				}
+			}
+		}
+
+		// 8a. gh-native: inspect the stacks the existing PRs belong to, and
+		// dissolve any that the append-only stacks API can no longer express
+		// (reorders, mid-stack inserts/removals, base changes) before any PR
+		// base is touched.
+		var stackPlans []nativeStackPlan
+		if opts.stackMode == stackModeNative {
+			stackPlans, err = prepareNativeStacks(client, groups, baseBranch, w)
+			if err != nil {
+				return err
+			}
+		}
+
 		for i := range activeStates {
 			s := &activeStates[i]
 			if s.pr != nil {
@@ -616,6 +723,27 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 						return fmt.Errorf("updating PR #%d title: %w", s.pr.Number, err)
 					}
 					s.changed = true
+				}
+
+				// Retarget the PR when its base does not match the chain
+				// (gh-native) — e.g. a new change was inserted below it. In the
+				// other modes jip must not override a base the user chose, so
+				// it only warns, and only when the base looks like a leftover
+				// chained base from an earlier gh-native send (it points at
+				// another branch in this send, so merging would land there
+				// instead of the base branch).
+				if base := desiredBase[s.change.ChangeID]; s.pr.BaseRefName != base {
+					switch {
+					case opts.stackMode == stackModeNative:
+						if err := client.UpdatePR(s.pr.Number, gh.UpdatePROpts{Base: &base}); err != nil {
+							return fmt.Errorf("updating PR #%d base: %w", s.pr.Number, err)
+						}
+						s.pr.BaseRefName = base
+						s.changed = true
+					case activeBookmarks[s.pr.BaseRefName]:
+						_, _ = fmt.Fprintf(w, "  warning: PR #%d targets %q, not %q — if this is a leftover from --stack=gh-native, retarget the PR on GitHub or re-send with --stack=gh-native\n",
+							s.pr.Number, s.pr.BaseRefName, base)
+					}
 				}
 
 				// Post "changes since" comment. By default the base is the old
@@ -640,7 +768,7 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 				if opts.pushOwner != "" {
 					head = opts.pushOwner + ":" + head
 				}
-				pr, err := client.CreatePR(head, baseBranch, title, s.change.Body(), opts.draft)
+				pr, err := client.CreatePR(head, desiredBase[s.change.ChangeID], title, s.change.Body(), opts.draft)
 				if err != nil {
 					return fmt.Errorf("creating PR for %s: %w", s.change.ChangeID, err)
 				}
@@ -655,19 +783,29 @@ func executeSend(runner jj.Runner, client gh.Service, opts sendOpts, w io.Writer
 			}
 		}
 
-		// 9. Update all PR bodies with stack navigation (skip nav when
-		// --no-stack) plus the invisible pushed-commit marker that records this
-		// push for a later --diff-since-jip.
+		// 8b. gh-native: link the PRs into native GitHub stacks now that every
+		// PR exists with a chained base.
+		if opts.stackMode == stackModeNative {
+			if err := finalizeNativeStacks(client, groups, stackPlans, w); err != nil {
+				return err
+			}
+		}
+
+		// 9. Update all PR bodies plus the invisible pushed-commit marker that
+		// records this push for a later --diff-since-jip. Stack navigation is
+		// rendered into the body only in default mode: with gh-native stacks
+		// GitHub's own UI shows the stack, and with --stack=none there is none.
 		//
 		// Each PR's stack only includes its ancestors and descendants (its
 		// dependency chain), not unrelated branches in the same DAG.
+		bodyNav := opts.stackMode == stackModeDefault
 		var perChangeStack [][]int
-		if !opts.noStack {
+		if bodyNav {
 			perChangeStack = computeStackPRs(activeStates)
 		}
 		for i, s := range activeStates {
 			body := s.change.Body()
-			if !opts.noStack {
+			if bodyNav {
 				body = gh.BuildStackedPRBody(
 					s.change.CommitID,
 					repoFullName,
@@ -860,6 +998,229 @@ func computeStackPRs(states []changeState) [][]int {
 		result[i] = prs
 	}
 	return result
+}
+
+// stackGroups splits states into connected groups, preserving topological
+// (bottom-to-top) order. Skipping a merge can disconnect one resolved DAG into
+// multiple stacks. The returned pointers alias the input slice, so later
+// mutations of the states are visible through the groups.
+func stackGroups(states []changeState) [][]*changeState {
+	byID := make(map[string]int, len(states))
+	for i := range states {
+		byID[states[i].change.ChangeID] = i
+	}
+
+	parent := make([]int, len(states))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(i int) int {
+		if parent[i] != i {
+			parent[i] = find(parent[i])
+		}
+		return parent[i]
+	}
+	for i := range states {
+		for _, parentID := range states[i].change.ParentIDs {
+			if parentIdx, ok := byID[parentID]; ok {
+				parent[find(i)] = find(parentIdx)
+			}
+		}
+	}
+
+	var groups [][]*changeState
+	groupByRoot := make(map[int]int)
+	for i := range states {
+		root := find(i)
+		group, ok := groupByRoot[root]
+		if !ok {
+			group = len(groups)
+			groupByRoot[root] = group
+			groups = append(groups, nil)
+		}
+		groups[group] = append(groups[group], &states[i])
+	}
+	return groups
+}
+
+// checkLinearStacks verifies that the active changes form linear chains:
+// no change may have more than one parent or child among the changes being
+// sent. GitHub native stacks cannot express branching dependency graphs.
+func checkLinearStacks(states []changeState) error {
+	inSet := make(map[string]bool, len(states))
+	for _, s := range states {
+		inSet[s.change.ChangeID] = true
+	}
+	parentCount := make(map[string]int)
+	childCount := make(map[string]int)
+	for _, s := range states {
+		for _, pid := range s.change.ParentIDs {
+			if inSet[pid] {
+				parentCount[s.change.ChangeID]++
+				childCount[pid]++
+			}
+		}
+	}
+	for _, s := range states {
+		id := s.change.ChangeID
+		if parentCount[id] > 1 {
+			return fmt.Errorf("--stack=gh-native requires linear stacks, but change %.12s (%s) has %d parents in the stack — reshape the stack or use --stack=default",
+				id, s.change.Title(), parentCount[id])
+		}
+		if childCount[id] > 1 {
+			return fmt.Errorf("--stack=gh-native requires linear stacks, but change %.12s (%s) has %d children in the stack — reshape the stack or use --stack=default",
+				id, s.change.Title(), childCount[id])
+		}
+	}
+	return nil
+}
+
+// nativeStackPlan records, per stack group, how to reconcile the local chain
+// with GitHub: leave keep untouched, append the chain PRs above prefixLen to
+// appendTo, or create a fresh stack when both are nil (incompatible remote
+// stacks were already dissolved by prepareNativeStacks).
+type nativeStackPlan struct {
+	appendTo  *gh.Stack
+	prefixLen int
+	keep      *gh.Stack
+}
+
+// prepareNativeStacks inspects the GitHub stacks that the existing PRs belong
+// to, before any PR is modified. The stacks API is append-only, so a remote
+// stack that no longer matches the local chain (reordered, mid-stack insert
+// or removal, changed base) is dissolved here and recreated later; dissolving
+// first keeps the PR base updates that follow from conflicting with
+// server-side stack state.
+func prepareNativeStacks(client gh.Service, groups [][]*changeState, baseBranch string, w io.Writer) ([]nativeStackPlan, error) {
+	plans := make([]nativeStackPlan, len(groups))
+	for gi, group := range groups {
+		// Existing PR numbers bottom-to-top; an existing PR above a new one
+		// would need a mid-stack insert, which appending cannot express.
+		var existing []int
+		sawNew, newBelowExisting := false, false
+		for _, s := range group {
+			if s.pr != nil {
+				if sawNew {
+					newBelowExisting = true
+				}
+				existing = append(existing, s.pr.Number)
+			} else {
+				sawNew = true
+			}
+		}
+
+		// Find the distinct stacks the existing PRs belong to. A PR belongs
+		// to at most one stack, so membership in a found stack answers the
+		// lookup for the other PRs it lists.
+		var stacks []*gh.Stack
+		resolved := make(map[int]bool)
+		for _, num := range existing {
+			if resolved[num] {
+				continue
+			}
+			resolved[num] = true
+			st, err := client.FindStackForPR(num)
+			if err != nil {
+				return nil, err
+			}
+			if st == nil {
+				continue
+			}
+			stacks = append(stacks, st)
+			for _, p := range st.PullRequests {
+				resolved[p.Number] = true
+			}
+		}
+
+		if len(stacks) == 0 {
+			continue // nothing on GitHub yet; a stack is created later
+		}
+
+		sameStack := len(stacks) == 1 && !newBelowExisting &&
+			stacks[0].Base.Ref == baseBranch
+		open := stacks[0].OpenPRNumbers()
+		switch {
+		case sameStack && slices.Equal(open, existing):
+			plans[gi] = nativeStackPlan{appendTo: stacks[0], prefixLen: len(existing)}
+			continue
+		case sameStack && len(existing) == len(group) && len(existing) < len(open) &&
+			slices.Equal(open[:len(existing)], existing):
+			// The remote stack extends above the changes being sent — a
+			// partial send (`jip send -r <mid-stack change>`), or descendants
+			// skipped for conflicts. Nothing local contradicts the stack and
+			// there is nothing to append, so leave it alone instead of
+			// tearing down PRs the user did not ask about.
+			plans[gi] = nativeStackPlan{keep: stacks[0]}
+			continue
+		}
+		for _, st := range stacks {
+			if err := dissolveStack(client, st.Number, w); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return plans, nil
+}
+
+// dissolveStack unstacks a GitHub stack, failing with an actionable error
+// when some PRs cannot be removed (merge-queued or auto-merge enabled).
+func dissolveStack(client gh.Service, number int, w io.Writer) error {
+	dissolved, err := client.Unstack(number)
+	if err != nil {
+		return fmt.Errorf("dissolving GitHub stack #%d: %w", number, err)
+	}
+	if !dissolved {
+		return fmt.Errorf("GitHub stack #%d could not be fully dissolved — some PRs are queued for merge or have auto-merge enabled; remove them from the queue and re-run", number)
+	}
+	_, _ = fmt.Fprintf(w, "Dissolved GitHub stack #%d (stack changed shape — it will be recreated)\n", number)
+	return nil
+}
+
+// finalizeNativeStacks creates or extends the native GitHub stack for each
+// group, once every PR exists with a chained base. Groups with a single PR
+// get no stack (GitHub requires at least two).
+func finalizeNativeStacks(client gh.Service, groups [][]*changeState, plans []nativeStackPlan, w io.Writer) error {
+	for gi, group := range groups {
+		chain := make([]int, len(group))
+		for i, s := range group {
+			chain[i] = s.pr.Number
+		}
+
+		plan := plans[gi]
+		if plan.keep != nil {
+			_, _ = fmt.Fprintf(w, "GitHub stack #%d: unchanged (it extends above the changes sent)\n", plan.keep.Number)
+			continue
+		}
+		if plan.appendTo != nil {
+			delta := chain[plan.prefixLen:]
+			if len(delta) == 0 {
+				_, _ = fmt.Fprintf(w, "GitHub stack #%d: up to date\n", plan.appendTo.Number)
+				continue
+			}
+			_, addErr := client.AddToStack(plan.appendTo.Number, delta)
+			if addErr == nil {
+				_, _ = fmt.Fprintf(w, "GitHub stack #%d: added %d PR(s)\n", plan.appendTo.Number, len(delta))
+				continue
+			}
+			// The append-only API rejects states we cannot always predict
+			// (e.g. after a partial merge) — recreate the stack instead.
+			_, _ = fmt.Fprintf(w, "warning: could not extend GitHub stack #%d (%v) — recreating it\n", plan.appendTo.Number, addErr)
+			if err := dissolveStack(client, plan.appendTo.Number, w); err != nil {
+				return err
+			}
+		}
+
+		if len(chain) < 2 {
+			continue
+		}
+		st, err := client.CreateStack(chain)
+		if err != nil {
+			return fmt.Errorf("creating GitHub stack: %w", err)
+		}
+		_, _ = fmt.Fprintf(w, "GitHub stack #%d: linked %d PR(s)\n", st.Number, len(chain))
+	}
+	return nil
 }
 
 // extractPushError extracts a clean reason from a jj git push error.

--- a/cmd/send_config_test.go
+++ b/cmd/send_config_test.go
@@ -94,6 +94,42 @@ func TestApplySendConfig_InvalidValue(t *testing.T) {
 	}
 }
 
+func TestResolveStackMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		stack        string
+		stackSet     bool
+		noStack      bool
+		noStackOnCLI bool
+		want         string
+		wantErr      bool
+	}{
+		{name: "default", stack: "default", want: "default"},
+		{name: "native", stack: "gh-native", stackSet: true, want: "gh-native"},
+		{name: "invalid value", stack: "nope", stackSet: true, wantErr: true},
+		{name: "no-stack alone", stack: "default", noStack: true, want: "none"},
+		{name: "config stack beats config no-stack", stack: "gh-native", stackSet: true, noStack: true, want: "gh-native"},
+		{name: "CLI no-stack beats config stack", stack: "gh-native", stackSet: true, noStack: true, noStackOnCLI: true, want: "none"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveStackMode(tt.stack, tt.stackSet, tt.noStack, tt.noStackOnCLI)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // Every key allowed in config must correspond to an actual send flag.
 func TestSendConfigKeys_MatchFlags(t *testing.T) {
 	for key := range sendConfigKeys {

--- a/cmd/send_integration_test.go
+++ b/cmd/send_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +26,15 @@ type mockService struct {
 	nextPR    int
 	owner     string
 	repo      string
+
+	// Native stacked-PRs state. stacksEnabled mirrors the private-preview
+	// gate; call counters let tests assert reconciliation behavior.
+	stacksEnabled    bool
+	stacks           map[int]*gh.Stack
+	nextStack        int
+	createStackCalls int
+	addToStackCalls  int
+	unstackCalls     int
 }
 
 func newMockService() *mockService {
@@ -35,6 +45,8 @@ func newMockService() *mockService {
 		nextPR:    1,
 		owner:     "testowner",
 		repo:      "testrepo",
+		stacks:    make(map[int]*gh.Stack),
+		nextStack: 1,
 	}
 }
 
@@ -109,6 +121,94 @@ func (m *mockService) LookupPRsByBranch(branches []string) (map[string]*gh.PRInf
 		}
 	}
 	return result, nil
+}
+
+func (m *mockService) StacksEnabled() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.stacksEnabled, nil
+}
+
+func (m *mockService) FindStackForPR(number int) (*gh.Stack, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, st := range m.stacks {
+		for _, p := range st.PullRequests {
+			if p.Number == number {
+				return st, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// checkChained enforces the API's base-to-head chain requirement: each PR's
+// base must be the head branch of the PR below it.
+func (m *mockService) checkChained(below, above int) error {
+	prBelow, prAbove := m.prs[below], m.prs[above]
+	if prBelow == nil || prAbove == nil {
+		return fmt.Errorf("unknown PR in stack request (#%d, #%d)", below, above)
+	}
+	if prAbove.BaseRefName != prBelow.HeadRefName {
+		return fmt.Errorf("PR #%d base %q does not match PR #%d head %q",
+			above, prAbove.BaseRefName, below, prBelow.HeadRefName)
+	}
+	return nil
+}
+
+func (m *mockService) CreateStack(prNumbers []int) (*gh.Stack, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createStackCalls++
+	if len(prNumbers) < 2 {
+		return nil, fmt.Errorf("a stack requires at least 2 PRs, got %d", len(prNumbers))
+	}
+	for i := 1; i < len(prNumbers); i++ {
+		if err := m.checkChained(prNumbers[i-1], prNumbers[i]); err != nil {
+			return nil, err
+		}
+	}
+	st := &gh.Stack{
+		Number: m.nextStack,
+		Open:   true,
+		Base:   gh.StackBase{Ref: m.prs[prNumbers[0]].BaseRefName},
+	}
+	m.nextStack++
+	for _, n := range prNumbers {
+		st.PullRequests = append(st.PullRequests, gh.StackPR{Number: n, State: "open"})
+	}
+	m.stacks[st.Number] = st
+	return st, nil
+}
+
+func (m *mockService) AddToStack(stackNumber int, prNumbers []int) (*gh.Stack, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.addToStackCalls++
+	st := m.stacks[stackNumber]
+	if st == nil {
+		return nil, fmt.Errorf("no such stack #%d", stackNumber)
+	}
+	prev := st.PullRequests[len(st.PullRequests)-1].Number
+	for _, n := range prNumbers {
+		if err := m.checkChained(prev, n); err != nil {
+			return nil, err
+		}
+		st.PullRequests = append(st.PullRequests, gh.StackPR{Number: n, State: "open"})
+		prev = n
+	}
+	return st, nil
+}
+
+func (m *mockService) Unstack(stackNumber int) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unstackCalls++
+	if _, ok := m.stacks[stackNumber]; !ok {
+		return false, fmt.Errorf("no such stack #%d", stackNumber)
+	}
+	delete(m.stacks, stackNumber)
+	return true, nil
 }
 
 func TestIntegration_SendCreatesNewPRs(t *testing.T) {
@@ -1036,10 +1136,10 @@ func TestIntegration_SendNoStack(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := executeSend(runner, mock, sendOpts{
-		base:    "main",
-		remote:  "origin",
-		revsets: []string{"@-"},
-		noStack: true,
+		base:      "main",
+		remote:    "origin",
+		revsets:   []string{"@-"},
+		stackMode: stackModeNone,
 	}, &buf)
 	if err != nil {
 		t.Fatalf("send --no-stack failed: %v\nOutput:\n%s", err, buf.String())
@@ -2157,4 +2257,539 @@ func writeAndCommit(t *testing.T, dir, filename, content, message string) {
 		t.Fatalf("writing %s: %v", filename, err)
 	}
 	jjRun(t, dir, "commit", "-m", message)
+}
+
+// singleStackPRNumbers returns the PR numbers of the single stack in the
+// mock, bottom to top. Fails the test unless exactly one stack exists.
+func singleStackPRNumbers(t *testing.T, m *mockService) []int {
+	t.Helper()
+	if len(m.stacks) != 1 {
+		t.Fatalf("expected exactly 1 GitHub stack, got %d", len(m.stacks))
+	}
+	for _, st := range m.stacks {
+		var nums []int
+		for _, p := range st.PullRequests {
+			nums = append(nums, p.Number)
+		}
+		return nums
+	}
+	return nil
+}
+
+func TestIntegration_SendNativeStackCreates(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two\n\nMore detail.")
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:      "main",
+		remote:    "origin",
+		revsets:   []string{"@-"},
+		stackMode: stackModeNative,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("send --stack=gh-native failed: %v\nOutput:\n%s", err, buf.String())
+	}
+	output := buf.String()
+	t.Logf("Output:\n%s", output)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.prs) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(mock.prs))
+	}
+	bottom, top := mock.prs[1], mock.prs[2]
+
+	// Bases must be chained: bottom targets main, top targets bottom's branch.
+	if bottom.BaseRefName != "main" {
+		t.Errorf("bottom PR base = %q, want main", bottom.BaseRefName)
+	}
+	if top.BaseRefName != bottom.HeadRefName {
+		t.Errorf("top PR base = %q, want bottom head %q", top.BaseRefName, bottom.HeadRefName)
+	}
+
+	// One native stack with both PRs, bottom to top.
+	if nums := singleStackPRNumbers(t, mock); !slices.Equal(nums, []int{1, 2}) {
+		t.Errorf("stack PRs = %v, want [1 2]", nums)
+	}
+
+	// Bodies carry the commit message and the pushed-commit marker, but no
+	// jip stack navigation (GitHub's UI shows the stack).
+	for _, pr := range mock.prs {
+		if strings.Contains(pr.Body, "stacked PR") || strings.Contains(pr.Body, "PRs:") {
+			t.Errorf("PR #%d body should not contain jip stack navigation:\n%s", pr.Number, pr.Body)
+		}
+		if !strings.Contains(pr.Body, "jip:pushed-commit=") {
+			t.Errorf("PR #%d body missing pushed-commit marker:\n%s", pr.Number, pr.Body)
+		}
+	}
+	if !strings.Contains(top.Body, "More detail.") {
+		t.Errorf("top PR body missing commit message body:\n%s", top.Body)
+	}
+
+	if !strings.Contains(output, "GitHub stack #1: linked 2 PR(s)") {
+		t.Errorf("expected stack link message in output, got:\n%s", output)
+	}
+}
+
+func TestIntegration_SendNativeStackSplitsAtPrivateMerge(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+	jjRun(t, repoDir, "config", "set", "--repo", "git.private-commits", "description(glob:'private:*')")
+
+	// Two independent stacks are connected only by a private merge:
+	// main -> A -> B -> C -> D --\
+	// main -> X ---------------- private merge
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: A")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: B")
+	writeAndCommit(t, repoDir, "c.go", "package c", "feat: C")
+	writeAndCommit(t, repoDir, "d.go", "package d", "feat: D")
+	chainTip := getChangeID(t, repoDir, "@-")
+
+	jjRun(t, repoDir, "new", "main")
+	writeAndCommit(t, repoDir, "x.go", "package x", "feat: X")
+	standalone := getChangeID(t, repoDir, "@-")
+
+	jjRun(t, repoDir, "new", chainTip, standalone)
+	writeAndCommit(t, repoDir, "merge.go", "package merge", "private: local merge")
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:      "main",
+		remote:    "origin",
+		revsets:   []string{"@-"},
+		stackMode: stackModeNative,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("send --stack=gh-native failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.prs) != 5 {
+		t.Fatalf("expected 5 PRs, got %d", len(mock.prs))
+	}
+	if len(mock.stacks) != 1 {
+		t.Fatalf("expected one four-PR native stack and one standalone PR, got %d native stacks", len(mock.stacks))
+	}
+
+	var stack *gh.Stack
+	for _, st := range mock.stacks {
+		stack = st
+	}
+	if len(stack.PullRequests) != 4 {
+		t.Fatalf("native stack has %d PRs, want 4", len(stack.PullRequests))
+	}
+	stackTitles := make(map[string]bool)
+	for _, p := range stack.PullRequests {
+		stackTitles[mock.prs[p.Number].Title] = true
+	}
+	for _, title := range []string{"feat: A", "feat: B", "feat: C", "feat: D"} {
+		if !stackTitles[title] {
+			t.Errorf("native stack missing %q", title)
+		}
+	}
+	for _, pr := range mock.prs {
+		if pr.Title == "feat: X" && pr.BaseRefName != "main" {
+			t.Errorf("standalone PR base = %q, want main", pr.BaseRefName)
+		}
+	}
+}
+
+func TestIntegration_SendNativeStackAppend(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two")
+
+	var buf bytes.Buffer
+	opts := sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, stackMode: stackModeNative}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("first send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	// New change on top of the stack: append, don't recreate.
+	writeAndCommit(t, repoDir, "c.go", "package c", "feat: part three")
+	buf.Reset()
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("second send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+	t.Logf("Output:\n%s", buf.String())
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if mock.addToStackCalls != 1 {
+		t.Errorf("addToStackCalls = %d, want 1", mock.addToStackCalls)
+	}
+	if mock.unstackCalls != 0 {
+		t.Errorf("unstackCalls = %d, want 0 (append must not recreate the stack)", mock.unstackCalls)
+	}
+	if mock.createStackCalls != 1 {
+		t.Errorf("createStackCalls = %d, want 1", mock.createStackCalls)
+	}
+	if nums := singleStackPRNumbers(t, mock); !slices.Equal(nums, []int{1, 2, 3}) {
+		t.Errorf("stack PRs = %v, want [1 2 3]", nums)
+	}
+	if !strings.Contains(buf.String(), "GitHub stack #1: added 1 PR(s)") {
+		t.Errorf("expected append message in output, got:\n%s", buf.String())
+	}
+}
+
+func TestIntegration_SendNativeStackUpToDate(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two")
+
+	var buf bytes.Buffer
+	opts := sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, stackMode: stackModeNative}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("first send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	buf.Reset()
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("second send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if mock.unstackCalls != 0 || mock.addToStackCalls != 0 || mock.createStackCalls != 1 {
+		t.Errorf("unchanged resend must not touch the stack: unstack=%d add=%d create=%d",
+			mock.unstackCalls, mock.addToStackCalls, mock.createStackCalls)
+	}
+	if !strings.Contains(buf.String(), "GitHub stack #1: up to date") {
+		t.Errorf("expected up-to-date message in output, got:\n%s", buf.String())
+	}
+}
+
+func TestIntegration_SendNativeStackRestructure(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two")
+	writeAndCommit(t, repoDir, "c.go", "package c", "feat: part three")
+
+	var buf bytes.Buffer
+	opts := sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, stackMode: stackModeNative}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("first send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	// Remove the middle change: the append-only stack API cannot express
+	// this, so jip must dissolve and recreate the stack.
+	midID := getChangeID(t, repoDir, "@--")
+	jjRun(t, repoDir, "abandon", "-r", midID)
+
+	buf.Reset()
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("second send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+	t.Logf("Output:\n%s", buf.String())
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if mock.unstackCalls != 1 {
+		t.Errorf("unstackCalls = %d, want 1", mock.unstackCalls)
+	}
+	if mock.createStackCalls != 2 {
+		t.Errorf("createStackCalls = %d, want 2", mock.createStackCalls)
+	}
+	if nums := singleStackPRNumbers(t, mock); !slices.Equal(nums, []int{1, 3}) {
+		t.Errorf("stack PRs = %v, want [1 3]", nums)
+	}
+	// The top PR must have been retargeted onto the bottom PR's branch.
+	if mock.prs[3].BaseRefName != mock.prs[1].HeadRefName {
+		t.Errorf("top PR base = %q, want %q", mock.prs[3].BaseRefName, mock.prs[1].HeadRefName)
+	}
+	if !strings.Contains(buf.String(), "Dissolved GitHub stack #1") {
+		t.Errorf("expected dissolve message in output, got:\n%s", buf.String())
+	}
+}
+
+func TestIntegration_SendNativeStackPartialSend(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two")
+	writeAndCommit(t, repoDir, "c.go", "package c", "feat: part three")
+
+	var buf bytes.Buffer
+	opts := sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, stackMode: stackModeNative}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("first send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	// Re-send only the bottom two changes. The remote stack extends above
+	// them, but nothing local contradicts it — jip must leave it alone rather
+	// than dissolving a stack the user did not ask about.
+	buf.Reset()
+	opts.revsets = []string{"@--"}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("partial send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+	t.Logf("Output:\n%s", buf.String())
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if mock.unstackCalls != 0 {
+		t.Errorf("unstackCalls = %d, want 0", mock.unstackCalls)
+	}
+	if mock.createStackCalls != 1 {
+		t.Errorf("createStackCalls = %d, want 1", mock.createStackCalls)
+	}
+	if nums := singleStackPRNumbers(t, mock); !slices.Equal(nums, []int{1, 2, 3}) {
+		t.Errorf("stack PRs = %v, want [1 2 3]", nums)
+	}
+	// The untouched top PR must keep its chained base.
+	if mock.prs[3].BaseRefName != mock.prs[2].HeadRefName {
+		t.Errorf("top PR base = %q, want %q", mock.prs[3].BaseRefName, mock.prs[2].HeadRefName)
+	}
+}
+
+func TestIntegration_SendNativeStackInsertBelow(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	idBottom := getChangeID(t, repoDir, "@-")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two")
+	idTop := getChangeID(t, repoDir, "@-")
+
+	var buf bytes.Buffer
+	opts := sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, stackMode: stackModeNative}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("first send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	// Insert a new change between the two: an existing PR ends up above a
+	// new one, which the append-only stack API cannot express — jip must
+	// dissolve and recreate the stack, retargeting the top PR mid-run.
+	jjRun(t, repoDir, "new", "--insert-after", idBottom)
+	writeAndCommit(t, repoDir, "m.go", "package m", "feat: part one and a half")
+
+	buf.Reset()
+	opts.revsets = []string{idTop}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("second send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+	t.Logf("Output:\n%s", buf.String())
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if mock.unstackCalls != 1 {
+		t.Errorf("unstackCalls = %d, want 1", mock.unstackCalls)
+	}
+	if mock.createStackCalls != 2 {
+		t.Errorf("createStackCalls = %d, want 2", mock.createStackCalls)
+	}
+	// Stack order is bottom to top: old bottom, inserted change, old top.
+	if nums := singleStackPRNumbers(t, mock); !slices.Equal(nums, []int{1, 3, 2}) {
+		t.Errorf("stack PRs = %v, want [1 3 2]", nums)
+	}
+	// Bases must be re-chained through the inserted PR.
+	if mock.prs[3].BaseRefName != mock.prs[1].HeadRefName {
+		t.Errorf("inserted PR base = %q, want %q", mock.prs[3].BaseRefName, mock.prs[1].HeadRefName)
+	}
+	if mock.prs[2].BaseRefName != mock.prs[3].HeadRefName {
+		t.Errorf("top PR base = %q, want %q", mock.prs[2].BaseRefName, mock.prs[3].HeadRefName)
+	}
+	if !strings.Contains(buf.String(), "Dissolved GitHub stack #1") {
+		t.Errorf("expected dissolve message in output, got:\n%s", buf.String())
+	}
+}
+
+func TestIntegration_SendDefaultWarnsOnChainedBase(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: part two")
+
+	var buf bytes.Buffer
+	opts := sendOpts{base: "main", remote: "origin", revsets: []string{"@-"}, stackMode: stackModeNative}
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("gh-native send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	// Switching back to default mode must not silently keep the top PR
+	// targeting the bottom PR's branch — merging it would land there
+	// instead of main. jip warns but does not retarget.
+	buf.Reset()
+	opts.stackMode = stackModeDefault
+	if err := executeSend(runner, mock, opts, &buf); err != nil {
+		t.Fatalf("default send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+	t.Logf("Output:\n%s", buf.String())
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if !strings.Contains(buf.String(), "warning: PR #2 targets") {
+		t.Errorf("expected chained-base warning in output, got:\n%s", buf.String())
+	}
+	if mock.prs[2].BaseRefName != mock.prs[1].HeadRefName {
+		t.Errorf("default mode must not retarget: PR #2 base = %q", mock.prs[2].BaseRefName)
+	}
+}
+
+func TestIntegration_SendNativeStackNotEnabled(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService() // stacksEnabled defaults to false
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: part one")
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:      "main",
+		remote:    "origin",
+		revsets:   []string{"@-"},
+		stackMode: stackModeNative,
+	}, &buf)
+	if err == nil {
+		t.Fatal("expected error when stacked PRs are not enabled")
+	}
+	if !strings.Contains(err.Error(), "not enabled") || !strings.Contains(err.Error(), "stacksbeta") {
+		t.Errorf("error should explain the preview gate, got: %v", err)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.prs) != 0 {
+		t.Errorf("no PRs must be created when the check fails, got %d", len(mock.prs))
+	}
+}
+
+func TestIntegration_SendNativeStackSinglePR(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: standalone")
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:      "main",
+		remote:    "origin",
+		revsets:   []string{"@-"},
+		stackMode: stackModeNative,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("send failed: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.prs) != 1 {
+		t.Fatalf("expected 1 PR, got %d", len(mock.prs))
+	}
+	if mock.createStackCalls != 0 || len(mock.stacks) != 0 {
+		t.Errorf("a single PR must not create a stack (calls=%d, stacks=%d)",
+			mock.createStackCalls, len(mock.stacks))
+	}
+}
+
+func TestIntegration_SendNativeStackNonLinear(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	// A fork: two children on top of the same change.
+	writeAndCommit(t, repoDir, "a.go", "package a", "feat: base change")
+	idA := getChangeID(t, repoDir, "@-")
+	writeAndCommit(t, repoDir, "b.go", "package b", "feat: branch B")
+	idB := getChangeID(t, repoDir, "@-")
+	jjRun(t, repoDir, "new", idA)
+	writeAndCommit(t, repoDir, "c.go", "package c", "feat: branch C")
+	idC := getChangeID(t, repoDir, "@-")
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:      "main",
+		remote:    "origin",
+		revsets:   []string{idB, idC},
+		stackMode: stackModeNative,
+	}, &buf)
+	if err == nil {
+		t.Fatal("expected error for non-linear stack in gh-native mode")
+	}
+	if !strings.Contains(err.Error(), "linear") {
+		t.Errorf("error should mention linearity, got: %v", err)
+	}
+}
+
+func TestIntegration_SendNativeStackCrossFork(t *testing.T) {
+	checkJJ(t)
+
+	mock := newMockService()
+	mock.stacksEnabled = true
+	repoDir, _ := initTestRepoWithRemote(t)
+	runner := jj.NewRunner(repoDir)
+
+	var buf bytes.Buffer
+	err := executeSend(runner, mock, sendOpts{
+		base:      "main",
+		remote:    "origin",
+		upstream:  "upstream",
+		revsets:   []string{"@-"},
+		stackMode: stackModeNative,
+	}, &buf)
+	if err == nil {
+		t.Fatal("expected error for --upstream with gh-native stacks")
+	}
+	if !strings.Contains(err.Error(), "forks") {
+		t.Errorf("error should mention forks, got: %v", err)
+	}
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -30,7 +30,8 @@ Global flags:
 | `--reviewer` | `-r` | | Add reviewers (repeatable, comma-separated) |
 | `--draft` | `-d` | | Create PRs as drafts |
 | `--existing` | `-x` | | Only update PRs that already exist (skip new ones) |
-| `--no-stack` | | | Send only the tip of each stack as a single PR |
+| `--stack` | | `default` | Stacking mode: `default` (stack navigation in PR descriptions), `gh-native` (GitHub's native stacked PRs), or `none` (send only the tip of each stack as a single PR) |
+| `--no-stack` | | | Deprecated — use `--stack=none` |
 | `--rebase` | | | Rebase the stack onto the base branch before sending |
 | `--diff-since-jip` | | | Diff against jip's own last send (recorded in the PR) instead of the current remote head |
 | `--no-change-comment` | | `default` | Comment posted when an updated PR has no code changes: `default`, `short`, or `none` |
@@ -57,7 +58,8 @@ from a team default without dirtying the committed `.jip.toml`. **Add
 `.jip.local.toml` to your `.gitignore`** — jip does not do this for you.
 
 Keys mirror the `send` flag names: `base`, `remote`, `upstream`, `draft`,
-`no-stack`, `rebase`, `diff-since-jip`, `reviewer`, `no-change-comment`.
+`stack`, `no-stack`, `rebase`, `diff-since-jip`, `reviewer`,
+`no-change-comment`.
 Per-invocation flags (`--dry-run`, `--existing`) cannot be set from config.
 
 ```toml
@@ -137,16 +139,51 @@ jip send --rebase
 This is equivalent to running `jj rebase` manually before `jip send`, but
 saves a step.
 
-## Single PR for a stack (`--no-stack`)
+## Stacking modes (`--stack`)
 
-By default, jip creates one PR per commit. Use `--no-stack` to bundle an
-entire linear stack into a single PR using the tip commit's bookmark and
-description. This is useful when all commits in the stack were already reviewed
-elsewhere (e.g. merging `main` into the `release` branch).
+By default, jip creates one PR per commit, all targeting the base branch, and
+renders stack navigation into each PR description. `--stack` selects other
+modes:
+
+### GitHub native stacked PRs (`--stack=gh-native`)
+
+Uses GitHub's built-in stacked-PRs feature (private preview — the repository
+must be enrolled via <https://gh.io/stacksbeta>). Each PR targets the branch
+of the change below it, and jip links the PRs into a native GitHub stack via
+the Stacks API — the same thing `gh stack link` does, without needing the `gh`
+CLI. GitHub's own UI then provides stack navigation, atomic merge-down, and
+server-side rebasing, so jip leaves PR descriptions as plain commit messages.
 
 ```bash
-jip send --no-stack
+jip send --stack=gh-native      # or set stack = "gh-native" in .jip.toml
 ```
+
+Notes:
+
+- Adding changes on top of a stack appends to the existing GitHub stack. The
+  Stacks API is append-only, so after reordering, removing, or inserting
+  changes mid-stack, jip dissolves the stack and recreates it (the PRs and
+  their reviews are untouched — only the stack association is rebuilt).
+- Sending only part of a stack (a narrower revset, or changes skipped for
+  conflicts) leaves the PRs above untouched: the GitHub stack is kept as is.
+- Stacks cannot span forks, so `--stack=gh-native` cannot be combined with
+  `--upstream`.
+- Branching (non-linear) stacks cannot be expressed; jip fails with an error.
+- If the repository is not enrolled in the preview, jip fails before making
+  any changes.
+
+### Single PR for a stack (`--stack=none`)
+
+Use `--stack=none` to bundle an entire linear stack into a single PR using the
+tip commit's bookmark and description. This is useful when all commits in the
+stack were already reviewed elsewhere (e.g. merging `main` into the `release`
+branch).
+
+```bash
+jip send --stack=none
+```
+
+The deprecated `--no-stack` flag is an alias for `--stack=none`.
 
 ## Diffing against jip's last send (`--diff-since-jip`)
 
@@ -168,7 +205,7 @@ jip send --diff-since-jip
 If the recorded commit isn't available locally (for example it was pushed from
 another machine and you haven't fetched it), jip can't compute the diff and
 instead posts a note saying so rather than a misleading one. jip writes the
-marker on every send (including `--no-stack` sends), and because each PR carries
+marker on every send (including `--stack=none` sends), and because each PR carries
 its own marker, this works across an entire stack. A PR only lacks a marker if
 jip has never sent it — for instance a PR created outside jip, or one last sent
 by a jip version predating this feature. In that case jip falls back to

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -147,10 +147,10 @@ jj new release main -m "chore: merge main into release"
 jj new
 
 # Send as a single PR (all 35 commits bundled, not stacked)
-jip s --base release --no-stack
+jip s --base release --stack=none
 ```
 
-The `--no-stack` flag tells jip to send a single PR for the tip of the stack
+`--stack=none` tells jip to send a single PR for the tip of the stack
 rather than one PR per commit. The reviewer sees one PR with the full diff from
 `release` to `main`.
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -21,6 +21,13 @@ type Service interface {
 	LookupPRsByBranch(branches []string) (map[string]*PRInfo, error)
 	Owner() string
 	Repo() string
+
+	// Native GitHub stacked-PRs (private preview) operations.
+	StacksEnabled() (bool, error)
+	FindStackForPR(number int) (*Stack, error)
+	CreateStack(prNumbers []int) (*Stack, error)
+	AddToStack(stackNumber int, prNumbers []int) (*Stack, error)
+	Unstack(stackNumber int) (dissolved bool, err error)
 }
 
 // Client wraps go-github for PR mutations and GraphQL queries.

--- a/internal/github/stacks.go
+++ b/internal/github/stacks.go
@@ -1,0 +1,196 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	gogithub "github.com/google/go-github/v68/github"
+
+	"github.com/omarkohl/jip/internal/retry"
+)
+
+// The Stacks REST API (repos/{owner}/{repo}/stacks...) backs GitHub's native
+// stacked-PRs private preview. It is not yet documented on docs.github.com;
+// endpoints and payload shapes mirror what the official gh-stack CLI
+// extension uses and may change before general availability.
+
+// StackPR is a pull request entry within a native GitHub stack.
+type StackPR struct {
+	Number   int     `json:"number"`
+	State    string  `json:"state"` // "open" or "closed"
+	Draft    bool    `json:"draft"`
+	MergedAt *string `json:"merged_at"`
+}
+
+// Merged reports whether the pull request has been merged.
+func (p StackPR) Merged() bool { return p.MergedAt != nil && *p.MergedAt != "" }
+
+// StackBase describes the base ref of a stack.
+type StackBase struct {
+	Ref string `json:"ref"`
+}
+
+// Stack is a native GitHub stack of pull requests. Number is the human-facing
+// stack number used in API paths; PullRequests is ordered bottom to top.
+type Stack struct {
+	Number       int       `json:"number"`
+	URL          string    `json:"url"`
+	Open         bool      `json:"open"`
+	Base         StackBase `json:"base"`
+	PullRequests []StackPR `json:"pull_requests"`
+}
+
+// OpenPRNumbers returns the numbers of the stack's open, unmerged PRs, bottom
+// to top. Merged PRs stay listed in a stack after a partial merge, so callers
+// comparing against a local stack must ignore them.
+func (s *Stack) OpenPRNumbers() []int {
+	var nums []int
+	for _, p := range s.PullRequests {
+		if p.State == "open" && !p.Merged() {
+			nums = append(nums, p.Number)
+		}
+	}
+	return nums
+}
+
+func (c *Client) stacksPath() string {
+	return fmt.Sprintf("repos/%s/%s/stacks", c.owner, c.repo)
+}
+
+// isNotFound reports whether err is a GitHub API 404 response.
+func isNotFound(err error) bool {
+	var ghErr *gogithub.ErrorResponse
+	return errors.As(err, &ghErr) && ghErr.Response != nil &&
+		ghErr.Response.StatusCode == http.StatusNotFound
+}
+
+// StacksEnabled reports whether the stacked-PRs preview is enabled for the
+// repository. The stacks endpoints answer 404 when it is not.
+func (c *Client) StacksEnabled() (bool, error) {
+	slog.Debug("StacksEnabled")
+	enabled := true
+	err := retry.Do(func() error {
+		req, err := c.gh.NewRequest(http.MethodGet, c.stacksPath(), nil)
+		if err != nil {
+			return err
+		}
+		var stacks []Stack
+		_, apiErr := c.gh.Do(context.Background(), req, &stacks)
+		if isNotFound(apiErr) {
+			enabled = false // a 404 is an answer, not a transient failure
+			return nil
+		}
+		return apiErr
+	})
+	if err != nil {
+		slog.Debug("StacksEnabled failed", "err", err)
+		return false, fmt.Errorf("checking stacked-PRs availability: %w", err)
+	}
+	slog.Debug("StacksEnabled ok", "enabled", enabled)
+	return enabled, nil
+}
+
+// FindStackForPR returns the stack containing the given PR, or nil when the
+// PR is not part of any stack.
+func (c *Client) FindStackForPR(number int) (*Stack, error) {
+	slog.Debug("FindStackForPR", "number", number)
+	var stacks []Stack
+	err := retry.Do(func() error {
+		path := fmt.Sprintf("%s?pull_request=%d", c.stacksPath(), number)
+		req, err := c.gh.NewRequest(http.MethodGet, path, nil)
+		if err != nil {
+			return err
+		}
+		_, apiErr := c.gh.Do(context.Background(), req, &stacks)
+		return apiErr
+	})
+	if err != nil {
+		slog.Debug("FindStackForPR failed", "number", number, "err", err)
+		return nil, fmt.Errorf("finding stack for PR #%d: %w", number, err)
+	}
+	if len(stacks) == 0 {
+		return nil, nil
+	}
+	return &stacks[0], nil
+}
+
+// stackRequest is the payload for stack create/add calls.
+type stackRequest struct {
+	PullRequests []int `json:"pull_requests"`
+}
+
+// CreateStack creates a native GitHub stack from PR numbers ordered bottom to
+// top. The PRs must already form a valid base-to-head chain (each PR based on
+// the head branch of the one below), and there must be at least two.
+func (c *Client) CreateStack(prNumbers []int) (*Stack, error) {
+	slog.Debug("CreateStack", "prs", prNumbers)
+	var stack Stack
+	err := retry.Do(func() error {
+		req, err := c.gh.NewRequest(http.MethodPost, c.stacksPath(), stackRequest{PullRequests: prNumbers})
+		if err != nil {
+			return err
+		}
+		_, apiErr := c.gh.Do(context.Background(), req, &stack)
+		return apiErr
+	})
+	if err != nil {
+		slog.Debug("CreateStack failed", "err", err)
+		return nil, fmt.Errorf("creating stack from PRs %v: %w", prNumbers, err)
+	}
+	slog.Debug("CreateStack ok", "number", stack.Number)
+	return &stack, nil
+}
+
+// AddToStack appends pull requests to the top of an existing stack. Only the
+// new PR numbers (the delta) are given, ordered from the current top upward.
+// The stacks API is append-only: reordering or mid-stack changes require
+// Unstack followed by CreateStack.
+func (c *Client) AddToStack(stackNumber int, prNumbers []int) (*Stack, error) {
+	slog.Debug("AddToStack", "stack", stackNumber, "prs", prNumbers)
+	var stack Stack
+	err := retry.Do(func() error {
+		path := fmt.Sprintf("%s/%d/add", c.stacksPath(), stackNumber)
+		req, err := c.gh.NewRequest(http.MethodPost, path, stackRequest{PullRequests: prNumbers})
+		if err != nil {
+			return err
+		}
+		_, apiErr := c.gh.Do(context.Background(), req, &stack)
+		return apiErr
+	})
+	if err != nil {
+		slog.Debug("AddToStack failed", "stack", stackNumber, "err", err)
+		return nil, fmt.Errorf("adding PRs %v to stack #%d: %w", prNumbers, stackNumber, err)
+	}
+	return &stack, nil
+}
+
+// Unstack removes the pull requests from a stack, dissolving it. The PRs
+// themselves survive. PRs queued for merge or with auto-merge enabled cannot
+// be removed; dissolved is false when any remain (HTTP 200 with the remaining
+// stack instead of 204).
+func (c *Client) Unstack(stackNumber int) (dissolved bool, err error) {
+	slog.Debug("Unstack", "stack", stackNumber)
+	err = retry.Do(func() error {
+		path := fmt.Sprintf("%s/%d/unstack", c.stacksPath(), stackNumber)
+		req, reqErr := c.gh.NewRequest(http.MethodPost, path, nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		var remaining Stack
+		resp, apiErr := c.gh.Do(context.Background(), req, &remaining)
+		if apiErr != nil {
+			return apiErr
+		}
+		dissolved = resp.StatusCode == http.StatusNoContent || len(remaining.PullRequests) == 0
+		return nil
+	})
+	if err != nil {
+		slog.Debug("Unstack failed", "stack", stackNumber, "err", err)
+		return false, fmt.Errorf("unstacking stack #%d: %w", stackNumber, err)
+	}
+	slog.Debug("Unstack ok", "stack", stackNumber, "dissolved", dissolved)
+	return dissolved, nil
+}


### PR DESCRIPTION
GitHub's stacked-PRs preview shows stack navigation in its own UI, so
jip no longer needs to render the stack into PR descriptions. In
gh-native mode each PR targets the branch below it and jip links the
chain through the Stacks REST API directly (no gh CLI needed). The
API is append-only, so reordered/removed/inserted changes dissolve
and recreate the stack (PRs and reviews survive).

--stack=none replaces the now-deprecated --no-stack.

<!-- jip:pushed-commit=9fdf58464acd8eed9ab5897c2fdacfebaa747868 -->