### PR TITLE
feat(config): support .local. config overrides

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -38,14 +38,23 @@ Global flags:
 ## Configuration files
 
 Workflow preferences can be set persistently instead of being passed as flags
-on every invocation. jip reads two TOML files:
+on every invocation. jip reads two TOML files, each of which may have a
+`.local.` sibling holding machine-specific overrides you don't want to share:
 
 1. **Global** — `~/.config/jip/config.toml` (the platform's user config dir,
-   e.g. `$XDG_CONFIG_HOME/jip/config.toml`)
+   e.g. `$XDG_CONFIG_HOME/jip/config.toml`), then
+   `~/.config/jip/config.local.toml`
 2. **Repo** — `.jip.toml` in the repository root (commit it to share team
-   defaults)
+   defaults), then `.jip.local.toml`
 
-Repo values override global values; CLI flags override both.
+Later files override earlier files; CLI flags override all config values. So a
+more specific location always wins, and a `.local.` file overrides its own
+sibling.
+
+The `.local.` files are for settings that shouldn't be shared: personal
+overrides alongside a `config.toml` tracked in your dotfiles, or a deviation
+from a team default without dirtying the committed `.jip.toml`. **Add
+`.jip.local.toml` to your `.gitignore`** — jip does not do this for you.
 
 Keys mirror the `send` flag names: `base`, `remote`, `upstream`, `draft`,
 `no-stack`, `rebase`, `diff-since-jip`, `reviewer`, `no-change-comment`.
@@ -58,10 +67,20 @@ diff-since-jip = true
 ```
 
 ```toml
+# ~/.config/jip/config.local.toml — machine-specific overrides
+upstream = "git@github.com:my-fork/project.git"
+```
+
+```toml
 # .jip.toml (repo root) — team defaults
 base = "dev"
 draft = true
 reviewer = ["alice", "team/backend"]
+```
+
+```toml
+# .jip.local.toml (repo root, gitignored) — your overrides for this repo
+draft = false
 ```
 
 ## Revsets

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,15 +1,22 @@
 // Package config loads jip's persistent preferences from TOML config files.
 //
-// Two locations are consulted, in order:
-//  1. Global: <user config dir>/jip/config.toml (e.g. ~/.config/jip/config.toml)
-//  2. Repo:   .jip.toml in the repository root
+// Two locations are consulted, and each may carry a .local. sibling holding
+// machine-specific overrides that should not be shared:
 //
-// Repo values override global values. CLI flags override both (enforced by
-// the caller, which only applies config to flags not set on the command line).
+//  1. Global: <user config dir>/jip/config.toml (e.g. ~/.config/jip/config.toml)
+//     then   <user config dir>/jip/config.local.toml
+//  2. Repo:   .jip.toml in the repository root
+//     then   .jip.local.toml (gitignore this)
+//
+// Later values override earlier values, so a more specific location always
+// wins and a .local. file overrides its own sibling. CLI flags override all
+// config values (enforced by the caller, which only applies config to flags
+// not set on the command line).
 package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -35,33 +42,39 @@ func GlobalPath() (string, error) {
 	return filepath.Join(dir, "jip", "config.toml"), nil
 }
 
-// Load reads the global and repo config files and returns a merged key→value
-// map with repo values taking precedence. Values are normalized to strings
-// ready to be applied to command-line flags (arrays are joined with commas).
-// Missing files are not an error; repoRoot may be empty to skip the repo file.
+// localSibling returns the machine-local override that sits next to path,
+// inserting ".local" before the extension: config.toml → config.local.toml,
+// .jip.toml → .jip.local.toml.
+func localSibling(path string) string {
+	ext := filepath.Ext(path)
+	return strings.TrimSuffix(path, ext) + ".local" + ext
+}
+
+// Load reads the config files and returns a merged key→value map, with later
+// files taking precedence. Values are normalized to strings ready to be
+// applied to command-line flags (arrays are joined with commas). Missing files
+// are not an error; repoRoot may be empty to skip the repo files.
 func Load(repoRoot string) (map[string]string, error) {
-	merged := make(map[string]string)
+	var bases []string
 
 	// The global config is an optional convenience: if its location can't be
 	// determined (e.g. os.UserConfigDir() fails because $HOME is unset),
 	// proceed as if there were no global config rather than aborting.
 	if globalPath, err := GlobalPath(); err == nil {
-		global, err := loadFile(globalPath)
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range global {
-			merged[k] = v
-		}
+		bases = append(bases, globalPath)
+	}
+	if repoRoot != "" {
+		bases = append(bases, filepath.Join(repoRoot, ".jip.toml"))
 	}
 
-	if repoRoot != "" {
-		repo, err := loadFile(filepath.Join(repoRoot, ".jip.toml"))
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range repo {
-			merged[k] = v
+	merged := make(map[string]string)
+	for _, base := range bases {
+		for _, path := range []string{base, localSibling(base)} {
+			cfg, err := loadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			maps.Copy(merged, cfg)
 		}
 	}
 	return merged, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,22 @@ func setGlobalConfig(t *testing.T, content string) {
 	}
 }
 
+// writeGlobalLocalConfig writes config.local.toml next to the global config.
+// It must be called after setGlobalConfig, which points Dir at a temp dir.
+func writeGlobalLocalConfig(t *testing.T, content string) {
+	t.Helper()
+	globalPath, err := GlobalPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(localSibling(globalPath), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // writeRepoConfig creates a temp repo root containing a .jip.toml.
 func writeRepoConfig(t *testing.T, content string) string {
 	t.Helper()
@@ -34,6 +50,14 @@ func writeRepoConfig(t *testing.T, content string) string {
 		t.Fatal(err)
 	}
 	return root
+}
+
+// writeRepoLocalConfig writes .jip.local.toml into an existing repo root.
+func writeRepoLocalConfig(t *testing.T, root, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, ".jip.local.toml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestLoad_MissingFiles(t *testing.T) {
@@ -63,6 +87,64 @@ func TestLoad_RepoOverridesGlobal(t *testing.T) {
 	for k, v := range want {
 		if cfg[k] != v {
 			t.Errorf("cfg[%q] = %q, want %q", k, cfg[k], v)
+		}
+	}
+}
+
+func TestLoad_GlobalLocalOverridesGlobal(t *testing.T) {
+	setGlobalConfig(t, "base = \"main\"\ndraft = false\n")
+	writeGlobalLocalConfig(t, "base = \"dev\"\nrebase = true\n")
+	root := writeRepoConfig(t, "base = \"release\"\n")
+
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]string{
+		"base":   "release", // repo overrides global local
+		"draft":  "false",   // global only
+		"rebase": "true",    // global local only
+	}
+	for k, v := range want {
+		if cfg[k] != v {
+			t.Errorf("cfg[%q] = %q, want %q", k, cfg[k], v)
+		}
+	}
+}
+
+// TestLoad_Precedence pins the full layering: each location overrides the one
+// before it, and a .local. file overrides its own sibling.
+func TestLoad_Precedence(t *testing.T) {
+	setGlobalConfig(t, "base = \"a\"\nremote = \"a\"\nupstream = \"a\"\ndraft = true\n")
+	writeGlobalLocalConfig(t, "base = \"b\"\nremote = \"b\"\nupstream = \"b\"\n")
+	root := writeRepoConfig(t, "base = \"c\"\nremote = \"c\"\n")
+	writeRepoLocalConfig(t, root, "base = \"d\"\n")
+
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]string{
+		"base":     "d",    // repo local wins over all
+		"remote":   "c",    // repo wins over global local
+		"upstream": "b",    // global local wins over global
+		"draft":    "true", // global only
+	}
+	for k, v := range want {
+		if cfg[k] != v {
+			t.Errorf("cfg[%q] = %q, want %q", k, cfg[k], v)
+		}
+	}
+}
+
+func TestLocalSibling(t *testing.T) {
+	tests := []struct{ path, want string }{
+		{filepath.Join("cfg", "config.toml"), filepath.Join("cfg", "config.local.toml")},
+		{filepath.Join("repo", ".jip.toml"), filepath.Join("repo", ".jip.local.toml")},
+	}
+	for _, tt := range tests {
+		if got := localSibling(tt.path); got != tt.want {
+			t.Errorf("localSibling(%q) = %q, want %q", tt.path, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
A global config.toml is often tracked in dotfiles and .jip.toml is committed
to share team defaults, leaving nowhere for settings that shouldn't be
shared. Each config file now picks up a .local. sibling that overrides it.

<!-- jip:pushed-commit=1d92a70cb6d05d7beb9c96451b48815e414d7ed1 -->